### PR TITLE
Added darkmode for 'session details' & 'FriendsChat'

### DIFF
--- a/app/(product)/components/BookSessionButton.tsx
+++ b/app/(product)/components/BookSessionButton.tsx
@@ -168,15 +168,13 @@ export default function BookSessionButton({
 
       {open && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-          {/* Changed popup background to dark theme */}
-          <div className="w-full max-w-md rounded-lg bg-[#181c2a] p-6 shadow-xl border border-[#23263a] text-white">
+          <div className="w-full max-w-md rounded-lg bg-white dark:bg-gray-900 p-6 shadow-xl border border-gray-200 dark:border-gray-800">
             <div className="flex items-start justify-between">
-              {/* Heading color changed to white */}
-              <h2 className="text-lg font-semibold text-white">
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
                 Book a session
               </h2>
               <button
-                className="text-sm text-gray-400 hover:text-white"
+                className="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
                 onClick={() => setOpen(false)}
                 disabled={busy}
               >
@@ -185,28 +183,23 @@ export default function BookSessionButton({
             </div>
 
             <div className="mt-4 space-y-4">
-              {/* Date + 12-hour time in 15-min slots (IST) */}
               <div>
-                {/* Label color changed to gray-300 */}
-                <label className="text-sm font-medium text-gray-300">
+                <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
                   Date &amp; time (IST)
                 </label>
 
                 <div className="mt-1 grid grid-cols-2 gap-2">
-                  {/* Date */}
                   <input
                     type="date"
-                    className="w-full rounded-md border border-[#23263a] bg-[#23263a] text-white px-3 py-2 text-sm"
+                    className="w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white px-3 py-2 text-sm"
                     value={dateIst}
                     onChange={(e) => setDateIst(e.target.value)}
                     disabled={busy}
                   />
 
-                  {/* Time: hour / minute / AM-PM */}
                   <div className="grid grid-cols-3 gap-2">
-                    {/* Hour 12h */}
                     <select
-                      className="rounded-md border border-[#23263a] bg-[#23263a] text-white px-2 py-2 text-sm"
+                      className="rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white px-2 py-2 text-sm"
                       value={hour12}
                       onChange={(e) =>
                         setHour12(
@@ -234,9 +227,8 @@ export default function BookSessionButton({
                       ))}
                     </select>
 
-                    {/* Minute (15-min steps) */}
                     <select
-                      className="rounded-md border border-[#23263a] bg-[#23263a] text-white px-2 py-2 text-sm"
+                      className="rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white px-2 py-2 text-sm"
                       value={minute}
                       onChange={(e) =>
                         setMinute(Number(e.target.value) as 0 | 15 | 30 | 45)
@@ -250,9 +242,8 @@ export default function BookSessionButton({
                       ))}
                     </select>
 
-                    {/* AM/PM */}
                     <select
-                      className="rounded-md border border-[#23263a] bg-[#23263a] text-white px-2 py-2 text-sm"
+                      className="rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white px-2 py-2 text-sm"
                       value={ampm}
                       onChange={(e) => setAmpm(e.target.value as "AM" | "PM")}
                       disabled={busy}
@@ -266,13 +257,13 @@ export default function BookSessionButton({
                   </div>
                 </div>
 
-                <p className="mt-1 text-[11px] text-gray-400">
+                <p className="mt-1 text-[11px] text-gray-500 dark:text-gray-400">
                   Time uses 15-minute increments (Asia/Kolkata).
                 </p>
               </div>
 
               <div>
-                <label className="text-sm font-medium text-gray-300">
+                <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
                   Duration
                 </label>
                 <div className="mt-2 grid grid-cols-3 gap-2">
@@ -283,8 +274,8 @@ export default function BookSessionButton({
                       onClick={() => setDuration(m as 25 | 50 | 75)}
                       className={`rounded-md border px-3 py-2 text-sm ${
                         duration === m
-                          ? "border-indigo-600 bg-indigo-900 text-indigo-300"
-                          : "border-[#23263a] bg-[#23263a] text-gray-300"
+                          ? "border-indigo-600 bg-indigo-50 text-indigo-700 dark:bg-indigo-900 dark:text-indigo-300"
+                          : "border-gray-300 bg-white text-gray-700 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300"
                       }`}
                       disabled={busy}
                     >
@@ -294,8 +285,7 @@ export default function BookSessionButton({
                 </div>
               </div>
               <div>
-
-                <label className="text-sm font-medium text-gray-300">
+                <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
                   Session type
                 </label>
                 <div className="mt-2 grid grid-cols-3 gap-2">
@@ -306,8 +296,8 @@ export default function BookSessionButton({
                       onClick={() => setSessionType(t)}
                       className={`rounded-md border px-3 py-2 text-sm capitalize ${
                         sessionType === t
-                          ? "border-green-600 bg-green-900 text-green-300"
-                          : "border-[#23263a] bg-[#23263a] text-gray-300"
+                          ? "border-green-600 bg-green-50 text-green-700 dark:bg-green-900 dark:text-green-300"
+                          : "border-gray-300 bg-white text-gray-700 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300"
                       }`}
                       disabled={busy}
                     >
@@ -317,10 +307,10 @@ export default function BookSessionButton({
                 </div>
               </div>
 
-              <label className="flex items-center gap-3 text-sm text-gray-300">
+              <label className="flex items-center gap-3 text-sm text-gray-700 dark:text-gray-300">
                 <input
                   type="checkbox"
-                  className="h-4 w-4 accent-[#23263a]"
+                  className="h-4 w-4 accent-gray-700 dark:accent-gray-300"
                   checked={quietOwner}
                   onChange={(e) => setQuietOwner(e.target.checked)}
                   disabled={busy}
@@ -329,28 +319,27 @@ export default function BookSessionButton({
               </label>
 
               {error && (
-                <div className="rounded-md bg-red-900/40 px-3 py-2 text-sm text-red-300">
+                <div className="rounded-md bg-red-100 dark:bg-red-900/40 px-3 py-2 text-sm text-red-700 dark:text-red-300">
                   {error}
                 </div>
               )}
               {success && (
-                <div className="rounded-md bg-green-900/40 px-3 py-2 text-sm text-green-300">
+                <div className="rounded-md bg-green-100 dark:bg-green-900/40 px-3 py-2 text-sm text-green-700 dark:text-green-300">
                   {success}
                 </div>
               )}
             </div>
 
-
             <div className="mt-6 flex justify-end gap-3">
               <button
-                className="rounded-md border border-[#23263a] bg-[#23263a] text-gray-300 px-4 py-2 text-sm hover:bg-[#23263a]/80"
+                className="rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-300 px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-800"
                 onClick={() => setOpen(false)}
                 disabled={busy}
               >
                 Cancel
               </button>
               <button
-                className="rounded-md bg-indigo-700 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-800 disabled:opacity-50"
+                className="rounded-md bg-indigo-600 dark:bg-indigo-700 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 dark:hover:bg-indigo-800 disabled:opacity-50"
                 onClick={handleCreate}
                 disabled={busy}
               >

--- a/app/(product)/components/Calendar.tsx
+++ b/app/(product)/components/Calendar.tsx
@@ -1067,17 +1067,17 @@ function BookingModal({
   onConfirm: () => void;
 }) {
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
-      <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
-        <h2 className="text-xl font-bold">Confirm Booking</h2>
-        <p className="mt-2 text-gray-600">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div className="w-full max-w-md rounded-lg bg-[#18181b] p-6 shadow-2xl border border-gray-800">
+        <h2 className="text-xl font-bold text-gray-100">Confirm Booking</h2>
+        <p className="mt-2 text-gray-300">
           You are booking a{" "}
-          <strong>
+          <strong className="text-white">
             {event.durationMin}-minute {event.sessionType}
           </strong>{" "}
           session for:
         </p>
-        <div className="mt-4 rounded-md bg-gray-100 p-3 text-center font-medium">
+        <div className="mt-4 rounded-md bg-gray-900/60 p-3 text-center font-medium text-gray-100">
           {new Date(event.start).toLocaleString("en-IN", {
             weekday: "long",
             month: "long",
@@ -1093,11 +1093,11 @@ function BookingModal({
           <input
             id="quiet-toggle"
             type="checkbox"
-            className="h-4 w-4"
+            className="h-4 w-4 accent-gray-700"
             checked={quiet}
             onChange={(e) => onChangeQuiet(e.target.checked)}
           />
-          <label htmlFor="quiet-toggle" className="text-sm text-gray-700">
+          <label htmlFor="quiet-toggle" className="text-sm text-gray-200">
             Quiet session (start muted)
           </label>
         </div>
@@ -1105,13 +1105,13 @@ function BookingModal({
         <div className="mt-6 flex justify-end gap-3">
           <button
             onClick={onClose}
-            className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium"
+            className="rounded-md border border-gray-700 bg-gray-900 text-gray-100 px-4 py-2 text-sm hover:bg-gray-800"
           >
             Cancel
           </button>
           <button
             onClick={onConfirm}
-            className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+            className="rounded-md bg-indigo-700 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-800"
           >
             Confirm
           </button>
@@ -1213,18 +1213,18 @@ function SessionDetailsModal({
     }
   };
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="w-full max-w-lg rounded-lg bg-white p-6 shadow-xl">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div className="w-full max-w-lg rounded-lg bg-[#18181b] p-6 shadow-2xl border border-gray-800">
         <div className="flex items-start justify-between">
-          <h2 className="text-xl font-bold">Session details</h2>
-          <button onClick={onClose} className="text-sm text-gray-500">
+          <h2 className="text-xl font-bold text-gray-100">Session details</h2>
+          <button onClick={onClose} className="text-sm text-gray-400 hover:text-gray-200">
             Close
           </button>
         </div>
-        <div className="mt-4 space-y-2 text-sm text-gray-700">
+        <div className="mt-4 space-y-2 text-sm text-gray-200">
           <div>
             <span className="font-medium">When:</span>
-            <div className="mt-1 rounded bg-gray-50 p-2">
+            <div className="mt-1 rounded bg-gray-900/60 p-2 text-gray-100">
               {new Date(event.start).toLocaleString("en-IN", {
                 timeZone: "Asia/Kolkata",
               })}{" "}
@@ -1241,31 +1241,31 @@ function SessionDetailsModal({
           {isOwner && (
             <div className="grid grid-cols-1 gap-3 pt-2">
               <div>
-                <label className="text-sm font-medium text-gray-700">
+                <label className="text-sm font-medium text-gray-300">
                   Session name
                 </label>
                 <input
-                  className="mt-1 w-full rounded-md border px-3 py-2 text-sm"
+                  className="mt-1 w-full rounded-md border border-gray-700 bg-gray-900 text-gray-100 px-3 py-2 text-sm"
                   placeholder="Optional name"
                   value={name}
                   onChange={(e) => setName(e.target.value)}
                 />
               </div>
               <div>
-                <label className="text-sm font-medium text-gray-700">
+                <label className="text-sm font-medium text-gray-300">
                   Color
                 </label>
                 <div className="mt-1 flex items-center gap-2">
                   <input
                     type="color"
-                    className="h-9 w-12 cursor-pointer rounded-md border p-1"
+                    className="h-9 w-12 cursor-pointer rounded-md border border-gray-700 bg-gray-900 p-1"
                     value={color || "#eef2ff"}
                     onChange={(e) => setColor(e.target.value)}
                     title="Pick a color"
                   />
                   <input
-                    className={`w-40 rounded-md border px-3 py-2 text-sm ${
-                      isColorValid ? "border-gray-300" : "border-red-500"
+                    className={`w-40 rounded-md border px-3 py-2 text-sm bg-gray-900 text-gray-100 ${
+                      isColorValid ? "border-gray-700" : "border-red-500"
                     }`}
                     placeholder="#eef2ff"
                     value={color}
@@ -1273,7 +1273,7 @@ function SessionDetailsModal({
                   />
                 </div>
                 {!isColorValid && (
-                  <p className="mt-1 text-xs text-red-600">
+                  <p className="mt-1 text-xs text-red-400">
                     Enter a valid hex color like #abc or #aabbcc
                   </p>
                 )}
@@ -1284,9 +1284,9 @@ function SessionDetailsModal({
             <div>
               <span className="font-medium">Partner:</span> {otherName}
               {other?.email ? (
-                <div className="text-xs text-gray-500">{other.email}</div>
+                <div className="text-xs text-gray-400">{other.email}</div>
               ) : null}
-              <div className="text-xs text-gray-500 mt-1 space-y-0.5">
+              <div className="text-xs text-gray-400 mt-1 space-y-0.5">
                 <div>You selected quiet: {selfQuiet ? "Yes" : "No"}</div>
                 <div>Partner selected quiet: {partnerQuiet ? "Yes" : "No"}</div>
               </div>
@@ -1296,7 +1296,7 @@ function SessionDetailsModal({
             <span className="font-medium">Join link:</span>
             <div className="mt-1 text-sm break-all">
               <a
-                className="text-indigo-600 hover:underline"
+                className="text-indigo-400 hover:underline"
                 href={`/sessions/${event.id}`}
               >
                 /sessions/{event.id}
@@ -1305,12 +1305,12 @@ function SessionDetailsModal({
           </div>
         </div>
         <div className="mt-6 flex flex-wrap items-center justify-between gap-2">
-          <div className="text-sm text-green-700">{friendReqStatus}</div>
+          <div className="text-sm text-green-400">{friendReqStatus}</div>
           <div className="flex gap-2">
             {other && !isFriend && (
               <button
                 onClick={sendFriendRequest}
-                className="rounded-md border border-indigo-200 bg-indigo-50 px-3 py-2 text-sm text-indigo-700 hover:bg-indigo-100"
+                className="rounded-md border border-indigo-700 bg-indigo-900 px-3 py-2 text-sm text-indigo-300 hover:bg-indigo-800"
               >
                 Send friend request
               </button>
@@ -1319,14 +1319,14 @@ function SessionDetailsModal({
               <button
                 onClick={handleSave}
                 disabled={saving || !isColorValid}
-                className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+                className="rounded-md bg-indigo-700 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-800 disabled:opacity-50"
               >
                 {saving ? "Saving..." : "Save"}
               </button>
             )}
             <button
               onClick={onClose}
-              className="rounded-md border px-4 py-2 text-sm"
+              className="rounded-md border border-gray-700 bg-gray-900 text-gray-100 px-4 py-2 text-sm hover:bg-gray-800"
             >
               Close
             </button>

--- a/app/(product)/components/Calendar.tsx
+++ b/app/(product)/components/Calendar.tsx
@@ -802,31 +802,12 @@ export default function Calendar({
                         style={{ top }}
                       >
                         <div
-                          style={{
-                            height,
-                            backgroundColor:
-                              ev.color ||
-                              (isBooked
-                                ? typeof window !== "undefined" &&
-                                  window.matchMedia &&
-                                  window.matchMedia(
-                                    "(prefers-color-scheme: dark)"
-                                  ).matches
-                                  ? "#374151"
-                                  : "#e5e7eb"
-                                : typeof window !== "undefined" &&
-                                  window.matchMedia &&
-                                  window.matchMedia(
-                                    "(prefers-color-scheme: dark)"
-                                  ).matches
-                                ? "#312e81"
-                                : "#eef2ff"),
-                          }}
-                          className={`rounded-lg p-2 flex flex-col justify-between ${
-                            isBooked
-                              ? "border border-gray-300 dark:border-gray-600"
-                              : "border border-indigo-200 hover:border-indigo-400 cursor-pointer dark:border-indigo-900"
-                          }`}
+                          style={{ height, ...(ev.color ? { backgroundColor: ev.color } : {}) }}
+                          className={`rounded-lg p-2 flex flex-col justify-between transition-colors
+                            ${isBooked
+                              ? 'border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-800'
+                              : 'border border-indigo-200 hover:border-indigo-400 cursor-pointer bg-indigo-50 dark:bg-indigo-900/30 dark:border-indigo-900'}
+                          `}
                           title={
                             tooltip
                               ? `${tooltip.label}${
@@ -1027,14 +1008,14 @@ function ConfirmModal({
       : "rounded-md bg-red-700 px-4 py-2 text-sm font-medium text-white hover:bg-red-800 disabled:opacity-50";
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="w-full max-w-md rounded-lg bg-[#181c2a] p-6 shadow-xl border border-[#23263a] text-white">
-        <h2 className="text-lg font-semibold text-white">{title}</h2>
+      <div className="w-full max-w-md rounded-lg bg-white dark:bg-gray-900 p-6 shadow-xl border border-gray-200 dark:border-gray-800 text-gray-900 dark:text-gray-100">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{title}</h2>
         {description && (
-          <div className="mt-3 text-sm text-gray-300">{description}</div>
+          <div className="mt-3 text-sm text-gray-700 dark:text-gray-300">{description}</div>
         )}
         <div className="mt-6 flex justify-end gap-3">
           <button
-            className="rounded-md border border-[#23263a] bg-[#23263a] text-gray-300 px-4 py-2 text-sm hover:bg-[#23263a]/80"
+            className="rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-800"
             onClick={onCancel}
             disabled={busy}
           >
@@ -1068,16 +1049,16 @@ function BookingModal({
 }) {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
-      <div className="w-full max-w-md rounded-lg bg-[#18181b] p-6 shadow-2xl border border-gray-800">
-        <h2 className="text-xl font-bold text-gray-100">Confirm Booking</h2>
-        <p className="mt-2 text-gray-300">
+      <div className="w-full max-w-md rounded-lg bg-white dark:bg-gray-900 p-6 shadow-2xl border border-gray-200 dark:border-gray-800">
+        <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">Confirm Booking</h2>
+        <p className="mt-2 text-gray-700 dark:text-gray-300">
           You are booking a{" "}
-          <strong className="text-white">
+          <strong className="text-indigo-700 dark:text-indigo-300">
             {event.durationMin}-minute {event.sessionType}
           </strong>{" "}
           session for:
         </p>
-        <div className="mt-4 rounded-md bg-gray-900/60 p-3 text-center font-medium text-gray-100">
+        <div className="mt-4 rounded-md bg-gray-100 dark:bg-gray-900/60 p-3 text-center font-medium text-gray-900 dark:text-gray-100">
           {new Date(event.start).toLocaleString("en-IN", {
             weekday: "long",
             month: "long",
@@ -1097,7 +1078,7 @@ function BookingModal({
             checked={quiet}
             onChange={(e) => onChangeQuiet(e.target.checked)}
           />
-          <label htmlFor="quiet-toggle" className="text-sm text-gray-200">
+          <label htmlFor="quiet-toggle" className="text-sm text-gray-700 dark:text-gray-200">
             Quiet session (start muted)
           </label>
         </div>
@@ -1105,13 +1086,13 @@ function BookingModal({
         <div className="mt-6 flex justify-end gap-3">
           <button
             onClick={onClose}
-            className="rounded-md border border-gray-700 bg-gray-900 text-gray-100 px-4 py-2 text-sm hover:bg-gray-800"
+            className="rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-800"
           >
             Cancel
           </button>
           <button
             onClick={onConfirm}
-            className="rounded-md bg-indigo-700 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-800"
+            className="rounded-md bg-indigo-600 dark:bg-indigo-700 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 dark:hover:bg-indigo-800"
           >
             Confirm
           </button>
@@ -1214,17 +1195,17 @@ function SessionDetailsModal({
   };
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
-      <div className="w-full max-w-lg rounded-lg bg-[#18181b] p-6 shadow-2xl border border-gray-800">
+      <div className="w-full max-w-lg rounded-lg bg-white dark:bg-gray-900 p-6 shadow-2xl border border-gray-200 dark:border-gray-800">
         <div className="flex items-start justify-between">
-          <h2 className="text-xl font-bold text-gray-100">Session details</h2>
-          <button onClick={onClose} className="text-sm text-gray-400 hover:text-gray-200">
+          <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">Session details</h2>
+          <button onClick={onClose} className="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200">
             Close
           </button>
         </div>
-        <div className="mt-4 space-y-2 text-sm text-gray-200">
+        <div className="mt-4 space-y-2 text-sm text-gray-700 dark:text-gray-200">
           <div>
             <span className="font-medium">When:</span>
-            <div className="mt-1 rounded bg-gray-900/60 p-2 text-gray-100">
+            <div className="mt-1 rounded bg-gray-100 dark:bg-gray-900/60 p-2 text-gray-900 dark:text-gray-100">
               {new Date(event.start).toLocaleString("en-IN", {
                 timeZone: "Asia/Kolkata",
               })}{" "}
@@ -1241,31 +1222,31 @@ function SessionDetailsModal({
           {isOwner && (
             <div className="grid grid-cols-1 gap-3 pt-2">
               <div>
-                <label className="text-sm font-medium text-gray-300">
+                <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
                   Session name
                 </label>
                 <input
-                  className="mt-1 w-full rounded-md border border-gray-700 bg-gray-900 text-gray-100 px-3 py-2 text-sm"
+                  className="mt-1 w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 px-3 py-2 text-sm"
                   placeholder="Optional name"
                   value={name}
                   onChange={(e) => setName(e.target.value)}
                 />
               </div>
               <div>
-                <label className="text-sm font-medium text-gray-300">
+                <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
                   Color
                 </label>
                 <div className="mt-1 flex items-center gap-2">
                   <input
                     type="color"
-                    className="h-9 w-12 cursor-pointer rounded-md border border-gray-700 bg-gray-900 p-1"
+                    className="h-9 w-12 cursor-pointer rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 p-1"
                     value={color || "#eef2ff"}
                     onChange={(e) => setColor(e.target.value)}
                     title="Pick a color"
                   />
                   <input
-                    className={`w-40 rounded-md border px-3 py-2 text-sm bg-gray-900 text-gray-100 ${
-                      isColorValid ? "border-gray-700" : "border-red-500"
+                    className={`w-40 rounded-md border px-3 py-2 text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 ${
+                      isColorValid ? "border-gray-300 dark:border-gray-700" : "border-red-500"
                     }`}
                     placeholder="#eef2ff"
                     value={color}
@@ -1273,7 +1254,7 @@ function SessionDetailsModal({
                   />
                 </div>
                 {!isColorValid && (
-                  <p className="mt-1 text-xs text-red-400">
+                  <p className="mt-1 text-xs text-red-600 dark:text-red-400">
                     Enter a valid hex color like #abc or #aabbcc
                   </p>
                 )}
@@ -1284,9 +1265,9 @@ function SessionDetailsModal({
             <div>
               <span className="font-medium">Partner:</span> {otherName}
               {other?.email ? (
-                <div className="text-xs text-gray-400">{other.email}</div>
+                <div className="text-xs text-gray-500 dark:text-gray-400">{other.email}</div>
               ) : null}
-              <div className="text-xs text-gray-400 mt-1 space-y-0.5">
+              <div className="text-xs text-gray-500 dark:text-gray-400 mt-1 space-y-0.5">
                 <div>You selected quiet: {selfQuiet ? "Yes" : "No"}</div>
                 <div>Partner selected quiet: {partnerQuiet ? "Yes" : "No"}</div>
               </div>
@@ -1296,7 +1277,7 @@ function SessionDetailsModal({
             <span className="font-medium">Join link:</span>
             <div className="mt-1 text-sm break-all">
               <a
-                className="text-indigo-400 hover:underline"
+                className="text-indigo-700 dark:text-indigo-300 hover:underline"
                 href={`/sessions/${event.id}`}
               >
                 /sessions/{event.id}
@@ -1305,12 +1286,12 @@ function SessionDetailsModal({
           </div>
         </div>
         <div className="mt-6 flex flex-wrap items-center justify-between gap-2">
-          <div className="text-sm text-green-400">{friendReqStatus}</div>
+          <div className="text-sm text-green-700 dark:text-green-400">{friendReqStatus}</div>
           <div className="flex gap-2">
             {other && !isFriend && (
               <button
                 onClick={sendFriendRequest}
-                className="rounded-md border border-indigo-700 bg-indigo-900 px-3 py-2 text-sm text-indigo-300 hover:bg-indigo-800"
+                className="rounded-md border border-indigo-600 dark:border-indigo-700 bg-indigo-50 dark:bg-indigo-900 px-3 py-2 text-sm text-indigo-700 dark:text-indigo-300 hover:bg-indigo-100 dark:hover:bg-indigo-800"
               >
                 Send friend request
               </button>
@@ -1319,14 +1300,14 @@ function SessionDetailsModal({
               <button
                 onClick={handleSave}
                 disabled={saving || !isColorValid}
-                className="rounded-md bg-indigo-700 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-800 disabled:opacity-50"
+                className="rounded-md bg-indigo-600 dark:bg-indigo-700 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 dark:hover:bg-indigo-800 disabled:opacity-50"
               >
                 {saving ? "Saving..." : "Save"}
               </button>
             )}
             <button
               onClick={onClose}
-              className="rounded-md border border-gray-700 bg-gray-900 text-gray-100 px-4 py-2 text-sm hover:bg-gray-800"
+              className="rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-800"
             >
               Close
             </button>

--- a/app/(product)/components/FriendChat.tsx
+++ b/app/(product)/components/FriendChat.tsx
@@ -250,19 +250,19 @@ export default function FriendChat({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
-      <div className="flex w-full max-w-lg flex-col rounded-md bg-[#18181b] shadow-2xl border border-gray-800">
-        <div className="flex items-center justify-between border-b border-gray-800 p-3">
+      <div className="flex w-full max-w-lg flex-col rounded-md bg-white dark:bg-gray-900 shadow-2xl border border-gray-200 dark:border-gray-800">
+        <div className="flex items-center justify-between border-b border-gray-200 dark:border-gray-800 p-3">
           <div className="flex items-center gap-2">
-            <div className="flex h-6 w-6 items-center justify-center rounded-full bg-purple-700 text-[10px] font-semibold text-white">
+            <div className="flex h-6 w-6 items-center justify-center rounded-full bg-purple-600 text-[10px] font-semibold text-white">
               {friendLabel?.[0]?.toUpperCase?.() || "F"}
             </div>
-            <div className="text-sm font-semibold text-gray-100">{friendLabel}</div>
+            <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">{friendLabel}</div>
           </div>
-          <button onClick={onClose} className="text-xs text-gray-400 hover:text-gray-200">
+          <button onClick={onClose} className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200">
             Close
           </button>
         </div>
-        {error && <div className="px-3 py-2 text-xs text-red-400">{error}</div>}
+        {error && <div className="px-3 py-2 text-xs text-red-700 dark:text-red-400">{error}</div>}
         <div ref={listRef} className="flex max-h-[70vh] flex-1 flex-col overflow-y-auto p-3">
           {loading && messages.length === 0 ? (
             <div className="text-xs text-gray-500">Loading…</div>
@@ -274,7 +274,7 @@ export default function FriendChat({
                   <div key={m.id} className={`flex ${isOwn ? "justify-end" : "justify-start"}`}>
                     <div
                       className={`max-w-[75%] rounded-lg border p-2 shadow-sm ${
-                        isOwn ? "bg-indigo-900 border-indigo-700 text-indigo-100" : "bg-gray-900 border-gray-700 text-gray-200"
+                        isOwn ? "bg-indigo-50 border-indigo-600 text-indigo-700 dark:bg-indigo-900 dark:border-indigo-700 dark:text-indigo-100" : "bg-gray-100 border-gray-300 text-gray-900 dark:bg-gray-900 dark:border-gray-700 dark:text-gray-200"
                       }`}
                     >
                       {renderMessage(m)}
@@ -288,12 +288,12 @@ export default function FriendChat({
             </div>
           )}
         </div>
-        <div className="sticky bottom-0 border-t border-gray-800 bg-[#18181b] p-3">
+        <div className="sticky bottom-0 border-t border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-3">
           <div className="flex items-center gap-2">
             <input
               type="text"
               placeholder="Type a message"
-              className="flex-1 rounded border border-gray-700 bg-gray-900 text-gray-100 px-2 py-1 text-sm focus:outline-none focus:border-indigo-700"
+              className="flex-1 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 px-2 py-1 text-sm focus:outline-none focus:border-indigo-600 dark:focus:border-indigo-700"
               value={text}
               onChange={(e) => setText(e.target.value)}
               onKeyDown={(e) => {
@@ -302,13 +302,13 @@ export default function FriendChat({
             />
             <button
               onClick={sendText}
-              className="rounded-md bg-indigo-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-800"
+              className="rounded-md bg-indigo-600 dark:bg-indigo-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-700 dark:hover:bg-indigo-800"
             >
               Send (Ctrl+Enter)
             </button>
             <button
               onClick={() => setSrOpen((v) => !v)}
-              className="rounded-md bg-green-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-green-800"
+              className="rounded-md bg-green-600 dark:bg-green-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-green-700 dark:hover:bg-green-800"
             >
               Session
             </button>
@@ -317,12 +317,12 @@ export default function FriendChat({
             <div className="flex flex-wrap items-center gap-2 mt-2">
               <input
                 type="datetime-local"
-                className="rounded border border-gray-700 bg-gray-900 text-gray-100 px-2 py-1 text-xs"
+                className="rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 px-2 py-1 text-xs"
                 value={srAt}
                 onChange={(e) => setSrAt(e.target.value)}
               />
               <select
-                className="rounded border border-gray-700 bg-gray-900 text-gray-100 px-2 py-1 text-xs"
+                className="rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 px-2 py-1 text-xs"
                 value={srDuration}
                 onChange={(e) => setSrDuration(Number(e.target.value) as 25 | 50 | 75)}
               >
@@ -333,13 +333,13 @@ export default function FriendChat({
               <input
                 type="text"
                 placeholder="Message (optional)"
-                className="w-48 rounded border border-gray-700 bg-gray-900 text-gray-100 px-2 py-1 text-xs"
+                className="w-48 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 px-2 py-1 text-xs"
                 value={srMessage}
                 onChange={(e) => setSrMessage(e.target.value)}
               />
               <button
                 onClick={sendSessionRequest}
-                className="rounded-md bg-green-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-green-800"
+                className="rounded-md bg-green-600 dark:bg-green-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-green-700 dark:hover:bg-green-800"
               >
                 Send request
               </button>

--- a/app/(product)/components/FriendChat.tsx
+++ b/app/(product)/components/FriendChat.tsx
@@ -249,20 +249,20 @@ export default function FriendChat({
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-      <div className="flex w-full max-w-lg flex-col rounded-md bg-white shadow-lg">
-        <div className="flex items-center justify-between border-b p-3">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div className="flex w-full max-w-lg flex-col rounded-md bg-[#18181b] shadow-2xl border border-gray-800">
+        <div className="flex items-center justify-between border-b border-gray-800 p-3">
           <div className="flex items-center gap-2">
-            <div className="flex h-6 w-6 items-center justify-center rounded-full bg-purple-600 text-[10px] font-semibold text-white">
+            <div className="flex h-6 w-6 items-center justify-center rounded-full bg-purple-700 text-[10px] font-semibold text-white">
               {friendLabel?.[0]?.toUpperCase?.() || "F"}
             </div>
-            <div className="text-sm font-semibold">{friendLabel}</div>
+            <div className="text-sm font-semibold text-gray-100">{friendLabel}</div>
           </div>
-          <button onClick={onClose} className="text-xs text-gray-600 hover:text-black">
+          <button onClick={onClose} className="text-xs text-gray-400 hover:text-gray-200">
             Close
           </button>
         </div>
-        {error && <div className="px-3 py-2 text-xs text-red-600">{error}</div>}
+        {error && <div className="px-3 py-2 text-xs text-red-400">{error}</div>}
         <div ref={listRef} className="flex max-h-[70vh] flex-1 flex-col overflow-y-auto p-3">
           {loading && messages.length === 0 ? (
             <div className="text-xs text-gray-500">Loading…</div>
@@ -274,7 +274,7 @@ export default function FriendChat({
                   <div key={m.id} className={`flex ${isOwn ? "justify-end" : "justify-start"}`}>
                     <div
                       className={`max-w-[75%] rounded-lg border p-2 shadow-sm ${
-                        isOwn ? "bg-blue-50 border-blue-100" : "bg-gray-50 border-gray-200"
+                        isOwn ? "bg-indigo-900 border-indigo-700 text-indigo-100" : "bg-gray-900 border-gray-700 text-gray-200"
                       }`}
                     >
                       {renderMessage(m)}
@@ -288,12 +288,12 @@ export default function FriendChat({
             </div>
           )}
         </div>
-        <div className="sticky bottom-0 border-t bg-white p-3">
+        <div className="sticky bottom-0 border-t border-gray-800 bg-[#18181b] p-3">
           <div className="flex items-center gap-2">
             <input
               type="text"
               placeholder="Type a message"
-              className="flex-1 rounded border px-2 py-1 text-sm"
+              className="flex-1 rounded border border-gray-700 bg-gray-900 text-gray-100 px-2 py-1 text-sm focus:outline-none focus:border-indigo-700"
               value={text}
               onChange={(e) => setText(e.target.value)}
               onKeyDown={(e) => {
@@ -302,27 +302,27 @@ export default function FriendChat({
             />
             <button
               onClick={sendText}
-              className="rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700"
+              className="rounded-md bg-indigo-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-800"
             >
               Send (Ctrl+Enter)
             </button>
             <button
               onClick={() => setSrOpen((v) => !v)}
-              className="rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-emerald-700"
+              className="rounded-md bg-green-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-green-800"
             >
               Session
             </button>
           </div>
           {srOpen && (
-            <div className="flex flex-wrap items-center gap-2">
+            <div className="flex flex-wrap items-center gap-2 mt-2">
               <input
                 type="datetime-local"
-                className="rounded border px-2 py-1 text-xs"
+                className="rounded border border-gray-700 bg-gray-900 text-gray-100 px-2 py-1 text-xs"
                 value={srAt}
                 onChange={(e) => setSrAt(e.target.value)}
               />
               <select
-                className="rounded border px-2 py-1 text-xs"
+                className="rounded border border-gray-700 bg-gray-900 text-gray-100 px-2 py-1 text-xs"
                 value={srDuration}
                 onChange={(e) => setSrDuration(Number(e.target.value) as 25 | 50 | 75)}
               >
@@ -333,13 +333,13 @@ export default function FriendChat({
               <input
                 type="text"
                 placeholder="Message (optional)"
-                className="w-48 rounded border px-2 py-1 text-xs"
+                className="w-48 rounded border border-gray-700 bg-gray-900 text-gray-100 px-2 py-1 text-xs"
                 value={srMessage}
                 onChange={(e) => setSrMessage(e.target.value)}
               />
               <button
                 onClick={sendSessionRequest}
-                className="rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-emerald-700"
+                className="rounded-md bg-green-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-green-800"
               >
                 Send request
               </button>


### PR DESCRIPTION
## Description

- Fixed [#37](https://github.com/PriyanshuShekhar10/refocus/issues/37) along with another UI fix including two UI issues related to color theming:
  1. Updated the **Send Friend Request** modal/page to use dark theme colors for background, text, borders, and buttons, matching the application's overall style.
  2. Updated the **FriendChat** modal/page to use dark theme colors for background, text, borders, and input fields, ensuring consistency with the rest of the app.

## Type of Change
* [x]  Bug fix
* [ ]  New feature
* [ ]  Breaking change
* [ ]  Documentation update

## Testing
* [x]  Tested locally
* [x]  All existing tests pass
* [ ]  New tests added (if applicable)

## Screenshots 

<img width="1506" height="1082" alt="image" src="https://github.com/user-attachments/assets/ff52c3b1-02b1-4b39-8fec-b71ba0c7ccb4" />

<img width="880" height="1084" alt="image" src="https://github.com/user-attachments/assets/ed461729-d857-4602-bba5-9e9adc28fa51" />


## Checklist
* [x]  Code follows the project's coding standards
* [x]  Self-review completed
* [x]  Documentation updated
* [x]  No console errors or

