### PR TITLE
Add global chat feature with message deletion and 24h retention

### DIFF
--- a/app/(product)/components/Sidebar/sidebar.tsx
+++ b/app/(product)/components/Sidebar/sidebar.tsx
@@ -8,8 +8,10 @@ import { FaUserFriends } from "react-icons/fa";
 import { HiSun, HiMoon } from "react-icons/hi";
 import { useTheme } from "next-themes";
 import { CgProfile } from "react-icons/cg";
+import { RiChat3Line } from "react-icons/ri";
+import Link from "next/link";
 
-export type TabKey = "profile" | "dashboard" | "settings" | "friends";
+export type TabKey = "profile" | "dashboard" | "settings" | "friends" | "chat";
 
 interface SideBarProps {
   activeTab: TabKey;
@@ -21,8 +23,7 @@ const SideBar: FC<SideBarProps> = ({ activeTab, onSelect }) => {
     <aside
       className="fixed top-0 left-0 h-screen w-16 flex flex-col
                  bg-white dark:bg-gray-900 shadow-sm z-40"
-      aria-label="Sidebar"
-    >
+      aria-label="Sidebar">
       <SideBarIcon
         icon={<MdDashboard size={20} />}
         text="Dashboard"
@@ -53,6 +54,13 @@ const SideBar: FC<SideBarProps> = ({ activeTab, onSelect }) => {
         active={activeTab === "friends"}
       />
 
+      <SideBarIcon
+        icon={<RiChat3Line size={18} />}
+        text="Global Chat"
+        onClick={() => onSelect("chat")}
+        active={activeTab === "chat"}
+      />
+
       <Divider />
 
       <SideBarIcon
@@ -75,6 +83,7 @@ interface SideBarIconProps {
   text?: string;
   onClick?: () => void;
   active?: boolean;
+  href?: string;
 }
 
 const SideBarIcon: FC<SideBarIconProps> = ({
@@ -82,6 +91,7 @@ const SideBarIcon: FC<SideBarIconProps> = ({
   text = "tooltip",
   onClick,
   active = false,
+  href,
 }) => {
   const base =
     "group relative flex items-center justify-center h-12 w-12 mt-3 mb-3 mx-auto rounded-3xl transition-all duration-200 ease-linear cursor-pointer shadow-sm";
@@ -89,14 +99,8 @@ const SideBarIcon: FC<SideBarIconProps> = ({
     ? "bg-green-600 text-white rounded-xl"
     : "bg-white border border-gray-200 dark:bg-gray-800 dark:border-gray-700 text-gray-600 dark:text-green-400 hover:bg-green-600 hover:text-white hover:rounded-xl";
 
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      aria-label={text}
-      title={text}
-      className={`${base} ${activeClasses}`}
-    >
+  const content = (
+    <>
       {icon}
       <span
         className="absolute left-16 top-1/2 -translate-y-1/2
@@ -105,10 +109,32 @@ const SideBarIcon: FC<SideBarIconProps> = ({
                    bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900
                    transform -translate-x-1 opacity-0
                    group-hover:translate-x-0 group-hover:opacity-100
-                   transition-transform transition-opacity duration-150 ease-out"
-      >
+                   transition-all duration-150 ease-out">
         {text}
       </span>
+    </>
+  );
+
+  if (href) {
+    return (
+      <Link
+        href={href}
+        aria-label={text}
+        title={text}
+        className={`${base} ${activeClasses}`}>
+        {content}
+      </Link>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={text}
+      title={text}
+      className={`${base} ${activeClasses}`}>
+      {content}
     </button>
   );
 };
@@ -131,8 +157,7 @@ const ThemeToggle: FC = () => {
                    h-12 w-12 mt-2 mx-auto
                    bg-white border border-gray-200 dark:bg-gray-800 dark:border-gray-700
                    rounded-3xl shadow-sm"
-        aria-hidden
-      >
+        aria-hidden>
         <HiSun size={18} />
       </div>
     );
@@ -153,8 +178,7 @@ const ThemeToggle: FC = () => {
                  transition-all duration-200 ease-linear
                  cursor-pointer shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-300"
       aria-label={`Switch to ${next} mode`}
-      title={`Switch to ${next} mode`}
-    >
+      title={`Switch to ${next} mode`}>
       {current === "dark" ? <HiSun size={18} /> : <HiMoon size={18} />}
 
       <span
@@ -164,8 +188,7 @@ const ThemeToggle: FC = () => {
                    bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900
                    transform -translate-x-1 opacity-0
                    group-hover:translate-x-0 group-hover:opacity-100
-                   transition-transform transition-opacity duration-150 ease-out"
-      >
+                   transition-all duration-150 ease-out">
         {current === "dark" ? "Light mode" : "Dark mode"}
       </span>
     </button>

--- a/app/(product)/components/globalchat.tsx
+++ b/app/(product)/components/globalchat.tsx
@@ -1,0 +1,316 @@
+"use client";
+
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Send, Trash2 } from "lucide-react";
+import { useSession } from "next-auth/react";
+
+type GlobalMessage = {
+  id: string;
+  user_id: string;
+  user_name?: string | null;
+  content: string;
+  created_at: string;
+  deleted?: boolean;
+  deleted_at?: string;
+};
+
+export default function GlobalChat() {
+  const { data: session } = useSession();
+  const currentUserId = (session?.user as { id?: string } | undefined)?.id;
+  const [messages, setMessages] = useState<GlobalMessage[]>([]);
+  const [text, setText] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSending, setIsSending] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [deletingIds, setDeletingIds] = useState<Set<string>>(new Set());
+  const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
+  const bottomRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const load = useMemo(
+    () =>
+      async function load() {
+        try {
+          const res = await fetch("/api/global-chat", { cache: "no-store" });
+          const data = await res.json();
+          if (!res.ok) throw new Error(data.error || "Failed to load messages");
+          setMessages(data.messages as GlobalMessage[]);
+        } catch (e) {
+          setError((e as Error).message);
+        } finally {
+          setIsLoading(false);
+        }
+      },
+    []
+  );
+
+  useEffect(() => {
+    load();
+    let es: EventSource | null = null;
+    try {
+      es = new EventSource("/api/global-chat/events");
+      es.onmessage = (ev) => {
+        try {
+          const data = JSON.parse(ev.data || "{}");
+          if (data?.type === "hello" || data?.type === "ping") return;
+          load();
+        } catch {}
+      };
+    } catch {}
+    return () => {
+      if (es) es.close();
+    };
+  }, [load]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages.length]);
+
+  const send = async () => {
+    const content = text.trim();
+    if (!content || isSending) return;
+    
+    setText("");
+    setIsSending(true);
+    setError(null);
+    
+    try {
+      const res = await fetch("/api/global-chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Failed to send");
+      await load();
+      inputRef.current?.focus();
+    } catch (e) {
+      setError((e as Error).message);
+      setText(content);
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      send();
+    }
+  };
+
+  const deleteMessage = async (messageId: string) => {
+    if (deletingIds.has(messageId)) return;
+    
+    setDeletingIds(prev => new Set(prev).add(messageId));
+    setDeleteConfirmId(null);
+    
+    try {
+      const res = await fetch(`/api/global-chat/${messageId}`, {
+        method: "DELETE",
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Failed to delete");
+      await load();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setDeletingIds(prev => {
+        const newSet = new Set(prev);
+        newSet.delete(messageId);
+        return newSet;
+      });
+    }
+  };
+
+  const formatTime = (dateString: string) => {
+    const date = new Date(dateString);
+    const now = new Date();
+    const diffInHours = (now.getTime() - date.getTime()) / (1000 * 60 * 60);
+    
+    if (diffInHours < 24) {
+      return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    }
+    return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
+  };
+
+  return (
+    <div className="flex flex-col h-[calc(100vh-3rem)]">
+      {/* Header */}
+      <div className="border-b border-gray-200 dark:border-gray-700 px-6 py-4">
+        <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
+          Global Chat
+        </h1>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          {messages.length} {messages.length === 1 ? 'message' : 'messages'}
+        </p>
+      </div>
+
+      {/* Error Message */}
+      {error && (
+        <div className="mx-6 mt-4 rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 px-4 py-3">
+          <div className="flex items-start justify-between gap-2">
+            <p className="text-sm text-red-800 dark:text-red-300">{error}</p>
+            <button
+              onClick={() => setError(null)}
+              className="text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-200 text-lg leading-none"
+            >
+              ×
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Delete Confirmation Modal */}
+      {deleteConfirmId && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 px-4">
+          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-md w-full p-6">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">
+              Delete Message?
+            </h3>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
+              Are you sure you want to delete this message? This action cannot be undone.
+            </p>
+            <div className="flex gap-3 justify-end">
+              <button
+                onClick={() => setDeleteConfirmId(null)}
+                className="px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors text-sm font-medium"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => deleteMessage(deleteConfirmId)}
+                className="px-4 py-2 rounded-lg bg-red-600 hover:bg-red-700 text-white transition-colors text-sm font-medium"
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Messages Area */}
+      <div className="flex-1 overflow-y-auto px-6 py-4">
+        {isLoading ? (
+          <div className="flex h-full items-center justify-center">
+            <div className="text-center">
+              <div className="w-8 h-8 border-4 border-gray-300 dark:border-gray-600 border-t-green-600 dark:border-t-green-500 rounded-full animate-spin mx-auto mb-3"></div>
+              <p className="text-gray-500 dark:text-gray-400 text-sm">
+                Loading messages...
+              </p>
+            </div>
+          </div>
+        ) : messages.length === 0 ? (
+          <div className="flex h-full items-center justify-center">
+            <div className="text-center">
+              <p className="text-gray-500 dark:text-gray-400 text-sm">
+                No messages yet. Start the conversation!
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-1">
+            {messages
+              .filter((m) => {
+                const messageDate = new Date(m.created_at);
+                const now = new Date();
+                const diffInHours = (now.getTime() - messageDate.getTime()) / (1000 * 60 * 60);
+                return diffInHours < 24;
+              })
+              .map((m, idx, filteredMessages) => {
+              const showDate = idx === 0 || 
+                new Date(filteredMessages[idx - 1].created_at).toDateString() !== 
+                new Date(m.created_at).toDateString();
+              
+              const isOwnMessage = m.user_id === currentUserId;
+              const isDeleting = deletingIds.has(m.id);
+              
+              return (
+                <React.Fragment key={m.id}>
+                  {showDate && (
+                    <div className="flex items-center justify-center py-4">
+                      <span className="text-xs text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-800 px-3 py-1 rounded-full">
+                        {new Date(m.created_at).toLocaleDateString([], { 
+                          month: 'long', 
+                          day: 'numeric',
+                          year: new Date(m.created_at).getFullYear() !== new Date().getFullYear() ? 'numeric' : undefined
+                        })}
+                      </span>
+                    </div>
+                  )}
+                  <div className="group rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800/50 px-4 py-2 transition-colors relative">
+                    <div className="flex items-start gap-3">
+                      <div className="w-8 h-8 rounded-full bg-green-600 flex items-center justify-center flex-shrink-0 mt-0.5">
+                        <span className="text-sm font-medium text-white">
+                          {(m.user_name || m.user_id).charAt(0).toUpperCase()}
+                        </span>
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-baseline gap-2">
+                          <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                            {m.user_name || m.user_id}
+                          </span>
+                          <span className="text-xs text-gray-400 dark:text-gray-500">
+                            {formatTime(m.created_at)}
+                          </span>
+                        </div>
+                        {m.deleted ? (
+                          <p className="text-sm text-gray-400 dark:text-gray-500 mt-1 italic">
+                            This message was deleted
+                          </p>
+                        ) : (
+                          <p className="text-sm text-gray-700 dark:text-gray-300 mt-1 whitespace-pre-wrap break-words leading-relaxed">
+                            {m.content}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                    {!m.deleted && isOwnMessage && (
+                      <div className="absolute inset-0 flex items-center justify-end opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">
+                        <button
+                          onClick={() => setDeleteConfirmId(m.id)}
+                          disabled={isDeleting}
+                          className="pointer-events-auto mr-3 bg-white dark:bg-gray-800 border border-red-200 dark:border-red-800 text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 dark:text-red-400 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg px-3 py-1.5 flex items-center gap-1.5 shadow-sm transition-colors"
+                          title="Delete message"
+                        >
+                          <Trash2 className="w-3.5 h-3.5" />
+                          <span className="text-xs font-medium">Delete</span>
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                </React.Fragment>
+              );
+            })}
+            <div ref={bottomRef} />
+          </div>
+        )}
+      </div>
+
+      {/* Input Area */}
+      <div className="border-t border-gray-200 dark:border-gray-700 px-6 py-4 bg-gray-50 dark:bg-gray-800/50">
+        <div className="flex gap-2">
+          <input
+            ref={inputRef}
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Type a message..."
+            disabled={isSending}
+            className="flex-1 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-4 py-2.5 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-green-500 dark:focus:ring-green-500 focus:border-transparent disabled:opacity-50 disabled:cursor-not-allowed"
+          />
+          <button
+            onClick={send}
+            disabled={!text.trim() || isSending}
+            className="rounded-lg bg-green-600 hover:bg-green-700 disabled:bg-gray-300 dark:disabled:bg-gray-700 disabled:cursor-not-allowed text-white px-4 py-2.5 flex items-center justify-center gap-2 transition-colors disabled:hover:bg-gray-300 dark:disabled:hover:bg-gray-700"
+          >
+            <Send className="w-4 h-4" />
+            <span className="text-sm font-medium hidden sm:inline">
+              {isSending ? 'Sending...' : 'Send'}
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(product)/dashboard/page.tsx
+++ b/app/(product)/dashboard/page.tsx
@@ -7,8 +7,10 @@ import Profile from "../components/profile";
 import Settings from "../components/settings";
 import Friends from "../components/friends";
 import Dashboard from "../components/dashboard";
+import GlobalChat from "../components/globalchat";
 
-type TabKey = "profile" | "dashboard" | "settings" | "friends";
+
+type TabKey = "profile" | "dashboard" | "settings" | "friends" | "chat";
 
 export default function DashboardPage() {
   const [activeTab, setActiveTab] = useState<TabKey>("dashboard");
@@ -21,6 +23,7 @@ export default function DashboardPage() {
         {activeTab === "profile" && <Profile />}
         {activeTab === "settings" && <Settings />}
         {activeTab === "friends" && <Friends />}
+        {activeTab === "chat" && <GlobalChat />}
       </main>
     </div>
   );

--- a/app/api/global-chat/[id]/route.ts
+++ b/app/api/global-chat/[id]/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getDb } from "@/lib/mongodb";
+import { ObjectId } from "mongodb";
+import { globalChatChannel, publish } from "@/lib/sse";
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  const currentUser = session?.user as { id?: string; name?: string } | undefined;
+  const currentUserId = currentUser?.id;
+  
+  if (!currentUserId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id: messageId } = await params;
+  
+  if (!messageId) {
+    return NextResponse.json({ error: "Message ID is required" }, { status: 400 });
+  }
+
+  try {
+    const db = await getDb();
+    
+    // First, check if the message exists and belongs to the current user
+    const message = await db.collection("global_messages").findOne({
+      _id: new ObjectId(messageId),
+    });
+
+    if (!message) {
+      return NextResponse.json({ error: "Message not found" }, { status: 404 });
+    }
+
+    if (message.user_id !== currentUserId) {
+      return NextResponse.json(
+        { error: "You can only delete your own messages" },
+        { status: 403 }
+      );
+    }
+
+    // Mark the message as deleted instead of removing it
+    const result = await db.collection("global_messages").updateOne(
+      { _id: new ObjectId(messageId) },
+      {
+        $set: {
+          deleted: true,
+          deleted_at: new Date(),
+          content: "[This message was deleted]",
+        },
+      }
+    );
+
+    if (result.modifiedCount === 0) {
+      return NextResponse.json({ error: "Failed to delete message" }, { status: 500 });
+    }
+
+    // Publish update event
+    publish(globalChatChannel(), { type: "message:deleted", payload: { id: messageId } });
+
+    return NextResponse.json({ success: true, id: messageId });
+  } catch (error) {
+    console.error("Error deleting message:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/global-chat/events/route.ts
+++ b/app/api/global-chat/events/route.ts
@@ -1,0 +1,38 @@
+import { globalChatChannel, subscribe } from "@/lib/sse";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  const currentUserId = (session?.user as { id?: string } | undefined)?.id;
+  if (!currentUserId) return new Response("Unauthorized", { status: 401 });
+
+  const channel = globalChatChannel();
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const encoder = new TextEncoder();
+      const send = (data: unknown) => controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+
+      send({ type: "hello" });
+      subscribe(channel, (event) => send(event));
+
+      setInterval(() => {
+        try {
+          send({ type: "ping", t: Date.now() });
+        } catch {}
+      }, 25000);
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}
+
+

--- a/app/api/global-chat/route.ts
+++ b/app/api/global-chat/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getDb } from "@/lib/mongodb";
+import { globalChatChannel } from "@/lib/sse";
+import { publish } from "@/lib/sse";
+
+type GlobalMessageDoc = {
+  _id: unknown;
+  user_id: string;
+  user_name?: string | null;
+  content: string;
+  created_at: Date;
+  deleted?: boolean;
+  deleted_at?: Date;
+};
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  const currentUserId = (session?.user as { id?: string; name?: string } | undefined)?.id;
+  if (!currentUserId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const db = await getDb();
+  const docs = (await db
+    .collection<GlobalMessageDoc>("global_messages")
+    .find({})
+    .sort({ created_at: 1 })
+    .limit(300)
+    .toArray()) as unknown as GlobalMessageDoc[];
+
+  return NextResponse.json({
+    messages: docs.map((m) => ({
+      id: String(m._id as string),
+      user_id: m.user_id,
+      user_name: m.user_name ?? null,
+      content: m.content,
+      created_at: m.created_at.toISOString(),
+      deleted: m.deleted ?? false,
+      deleted_at: m.deleted_at?.toISOString() ?? null,
+    })),
+  });
+}
+
+export async function POST(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  const currentUser = session?.user as { id?: string; name?: string } | undefined;
+  const currentUserId = currentUser?.id;
+  if (!currentUserId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const body = await req.json().catch(() => ({}));
+  const { content } = body as { content?: string };
+  if (!content || !content.trim())
+    return NextResponse.json({ error: "Empty content" }, { status: 400 });
+
+  const db = await getDb();
+  const insert = await db.collection("global_messages").insertOne({
+    user_id: currentUserId,
+    user_name: currentUser?.name ?? null,
+    content: content.trim(),
+    created_at: new Date(),
+  });
+
+  publish(globalChatChannel(), { type: "message:new", payload: { id: String(insert.insertedId) } });
+  return NextResponse.json({ id: String(insert.insertedId) });
+}
+
+

--- a/lib/sse.ts
+++ b/lib/sse.ts
@@ -43,4 +43,8 @@ export function userChannel(userId: string) {
   return `user:${userId}:chat`;
 }
 
+export function globalChatChannel() {
+  return `chat:global`;
+}
+
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -8,9 +8,12 @@ export const config = {
     "/features/:path*",
     "/notes/:path*",
     "/sessions/:path*",
+    "/chat/:path*",
+    "/global-chat/:path*",
     // Explicitly protect API namespaces (avoid regex lookaheads which are unsupported)
     "/api/friends/:path*",
     "/api/sessions/:path*",
     "/api/users/:path*",
+    "/api/global-chat/:path*",
   ],
 };


### PR DESCRIPTION


# Add Global Chat with Message Deletion and 24h Retention

## Description

This PR implements a real-time **Global Chat** feature with message deletion capabilities and UI-based 24-hour message retention.
- Fixes: #47 

## Features

### Global Chat Component
- Real-time messaging using Server-Sent Events (SSE)
- Clean UI with dark mode support
- Mobile responsive design

### Message Deletion
- Users can delete their own messages with confirmation modal
- Soft delete: Shows "This message was deleted" placeholder
- Messages retained in database for audit purposes

### 24-Hour UI Retention
- Only displays messages from last 24 hours in UI
- All messages stored permanently in database

## Implementation

### New Files
- `app/(product)/components/globalchat.tsx` - Main chat component
- `app/api/global-chat/route.ts` - GET/POST endpoints
- `app/api/global-chat/[id]/route.ts` - DELETE endpoint
- `app/api/global-chat/events/route.ts` - SSE endpoint

### Modified Files
- `app/(product)/components/Sidebar/sidebar.tsx` - Navigation fixes
- `lib/sse.ts` - Added `globalChatChannel()`
- `middleware.ts` - Protected routes

### API Endpoints
- `GET /api/global-chat` - Fetch messages (300 limit)
- `POST /api/global-chat` - Send message
- `DELETE /api/global-chat/[id]` - Soft delete (owner only)
- `GET /api/global-chat/events` - Real-time updates via SSE

### Database Schema
Added to `global_messages` collection:
```typescript
{
  deleted?: boolean,
  deleted_at?: Date
}
```

## Security
- Authentication required for all endpoints
- Authorization: Users can only delete own messages
- Input validation on message content
- Proper HTTP status codes (401, 403, 404, 500)

## Testing
- [x] Manual testing across multiple browsers
- [x] Real-time updates verified
- [x] Delete functionality with proper authorization
- [x] Dark mode and responsive design
- [x] `npm run lint` - No warnings
- [x] `npm run build` - Successful



---

**Demo**

https://github.com/user-attachments/assets/0e2b1913-38b5-48e8-bc16-40f7ad382534

