### PR TITLE
Require verified email for interactions (browse-only until verified)

### DIFF
--- a/__tests__/lib/requireVerifiedEmail.test.ts
+++ b/__tests__/lib/requireVerifiedEmail.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ObjectId } from "mongodb";
+
+vi.unmock("@/lib/requireVerifiedEmail");
+
+const findOne = vi.fn();
+
+vi.mock("@/lib/mongodb", () => ({
+  getDb: vi.fn().mockResolvedValue({
+    collection: () => ({ findOne }),
+  }),
+}));
+
+describe("requireVerifiedEmail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns null when the user is verified", async () => {
+    findOne.mockResolvedValue({ emailVerified: new Date() });
+    const { requireVerifiedEmail } = await import("@/lib/requireVerifiedEmail");
+    const userId = new ObjectId().toString();
+
+    await expect(requireVerifiedEmail(userId)).resolves.toBeNull();
+  });
+
+  it("returns 403 when the user is not verified", async () => {
+    findOne.mockResolvedValue({ emailVerified: null });
+    const { requireVerifiedEmail, EMAIL_NOT_VERIFIED_CODE } = await import(
+      "@/lib/requireVerifiedEmail"
+    );
+    const userId = new ObjectId().toString();
+
+    const res = await requireVerifiedEmail(userId);
+    expect(res?.status).toBe(403);
+    const body = await res!.json();
+    expect(body.code).toBe(EMAIL_NOT_VERIFIED_CODE);
+  });
+});

--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -22,3 +22,12 @@ vi.mock("@/lib/sse", () => ({
   userChannel: vi.fn((id: string) => `user:${id}`),
   sessionsChannel: vi.fn(() => "sessions"),
 }));
+
+vi.mock("@/lib/requireVerifiedEmail", () => ({
+  EMAIL_NOT_VERIFIED_CODE: "EMAIL_NOT_VERIFIED",
+  EMAIL_VERIFICATION_REQUIRED_MESSAGE:
+    "Verify your email to use this feature. You can browse until then.",
+  getUserEmailVerified: vi.fn().mockResolvedValue(true),
+  emailNotVerifiedResponse: vi.fn(),
+  requireVerifiedEmail: vi.fn().mockResolvedValue(null),
+}));

--- a/app/(product)/components/BookSessionButton.tsx
+++ b/app/(product)/components/BookSessionButton.tsx
@@ -5,6 +5,7 @@ import {
   isValidDuration,
   type DurationMin,
 } from "@/constants/calendar";
+import { useEmailVerified } from "@/hooks/useEmailVerified";
 
 export type CreatedSession = {
   id: string;
@@ -30,6 +31,7 @@ export default function BookSessionButton({
   defaultSessionType = "focus",
   onCreated,
 }: Props) {
+  const { canInteract, message: verifyMessage } = useEmailVerified();
   const [open, setOpen] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -219,8 +221,10 @@ export default function BookSessionButton({
     <>
       <button
         data-book-session-trigger
-        className={`w-full rounded-md bg-[#5D1C6A] px-3 py-2 text-sm font-medium text-white hover:bg-[#CA5995] ${className}`}
-        onClick={() => setOpen(true)}
+        className={`w-full rounded-md bg-[#5D1C6A] px-3 py-2 text-sm font-medium text-white hover:bg-[#CA5995] disabled:cursor-not-allowed disabled:opacity-50 ${className}`}
+        onClick={() => canInteract && setOpen(true)}
+        disabled={!canInteract}
+        title={!canInteract ? verifyMessage : undefined}
       >
         {label}
       </button>

--- a/app/(product)/components/Community/Community.tsx
+++ b/app/(product)/components/Community/Community.tsx
@@ -8,6 +8,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Loader2, MessageSquare } from "lucide-react";
 import PostCard, { Post, Comment } from "./PostCard";
 import CommunityChat from "./CommunityChat";
+import { useEmailVerified } from "@/hooks/useEmailVerified";
 
 type ProfilePreviewPayload = {
   username: string;
@@ -69,6 +70,7 @@ export default function Community({ onPreviewProfile }: CommunityProps) {
   const [posting, setPosting] = useState(false);
   const [showChat, setShowChat] = useState(true);
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
+  const { canInteract, message: verifyMessage } = useEmailVerified();
 
   const loadPosts = useCallback(async (cursor?: string) => {
     try {
@@ -116,7 +118,7 @@ export default function Community({ onPreviewProfile }: CommunityProps) {
   }, [nextCursor, loadingMore, loadPosts]);
 
   const handlePost = async () => {
-    if (!newPostContent.trim() || posting) return;
+    if (!canInteract || !newPostContent.trim() || posting) return;
     setPosting(true);
 
     try {
@@ -137,6 +139,7 @@ export default function Community({ onPreviewProfile }: CommunityProps) {
   };
 
   const handleLike = async (postId: string) => {
+    if (!canInteract) return;
     try {
       const res = await fetch(`/api/community/posts/${postId}/like`, {
         method: "POST",
@@ -157,6 +160,7 @@ export default function Community({ onPreviewProfile }: CommunityProps) {
   };
 
   const handleDelete = async (postId: string) => {
+    if (!canInteract) return;
     // Optimistic delete
     setPosts((prev) => prev.filter((p) => p.id !== postId));
 
@@ -177,6 +181,7 @@ export default function Community({ onPreviewProfile }: CommunityProps) {
     postId: string,
     content: string
   ): Promise<Comment | null> => {
+    if (!canInteract) return null;
     try {
       const res = await fetch(`/api/community/posts/${postId}/comments`, {
         method: "POST",
@@ -220,8 +225,13 @@ export default function Community({ onPreviewProfile }: CommunityProps) {
                   <Textarea
                     value={newPostContent}
                     onChange={(e) => setNewPostContent(e.target.value)}
-                    placeholder="What's on your mind?"
-                    className="min-h-[80px] resize-none border-0 p-0 focus-visible:ring-0 shadow-none"
+                    placeholder={
+                      canInteract
+                        ? "What's on your mind?"
+                        : verifyMessage
+                    }
+                    disabled={!canInteract}
+                    className="min-h-[80px] resize-none border-0 p-0 focus-visible:ring-0 shadow-none disabled:opacity-60"
                   />
                   <div className="flex items-center justify-between mt-3 pt-3 border-t border-border">
                     {/* <div className="flex gap-2">
@@ -233,7 +243,8 @@ export default function Community({ onPreviewProfile }: CommunityProps) {
                     <Button
                       size="sm"
                       onClick={handlePost}
-                      disabled={!newPostContent.trim() || posting}
+                      disabled={!canInteract || !newPostContent.trim() || posting}
+                      title={!canInteract ? verifyMessage : undefined}
                       className="bg-[#5D1C6A] hover:bg-[#CA5995]"
                     >
                       {posting ? (

--- a/app/(product)/components/Community/CommunityChat.tsx
+++ b/app/(product)/components/Community/CommunityChat.tsx
@@ -7,6 +7,7 @@ import { VerifiedName } from "@/components/verified-tag";
 import { useSession } from "next-auth/react";
 import { getAblyClient } from "@/lib/ably-client";
 import { globalChatChannel } from "@/lib/realtimeChannels";
+import { useEmailVerified } from "@/hooks/useEmailVerified";
 
 type GlobalMessage = {
   id: string;
@@ -27,16 +28,10 @@ export default function CommunityChat() {
   const [text, setText] = useState("");
   const [isSending, setIsSending] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
-  const [myEmailVerified, setMyEmailVerified] = useState(false);
+  const { canInteract, verified: myEmailVerified, message: verifyMessage } =
+    useEmailVerified();
   const bottomRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
-
-  useEffect(() => {
-    fetch("/api/users/me")
-      .then((res) => res.json())
-      .then((data) => setMyEmailVerified(!!data?.user?.emailVerified))
-      .catch(() => {});
-  }, []);
 
   const load = useCallback(async () => {
     try {
@@ -120,7 +115,7 @@ export default function CommunityChat() {
 
   const send = async () => {
     const content = text.trim();
-    if (!content || isSending) return;
+    if (!content || isSending || !canInteract) return;
 
     const tempId = `temp-${Date.now()}`;
     const userName = (session?.user as { name?: string } | undefined)?.name ?? null;
@@ -273,7 +268,7 @@ export default function CommunityChat() {
                       ) : (
                         <VerifiedName
                           name={isOwn ? "You" : name}
-                          verified={isOwn ? (m.emailVerified ?? myEmailVerified) : m.emailVerified}
+                          verified={isOwn ? (m.emailVerified ?? myEmailVerified === true) : m.emailVerified}
                           className="text-[10px] font-medium text-muted-foreground"
                         />
                       )}
@@ -315,13 +310,13 @@ export default function CommunityChat() {
             value={text}
             onChange={(e) => setText(e.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder="Message..."
-            disabled={isSending}
+            placeholder={canInteract ? "Message..." : verifyMessage}
+            disabled={isSending || !canInteract}
             className="flex-1 h-8 px-3 text-xs rounded-lg border border-input bg-background focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-50"
           />
           <button
             onClick={send}
-            disabled={!text.trim() || isSending}
+            disabled={!text.trim() || isSending || !canInteract}
             className="shrink-0 h-8 w-8 flex items-center justify-center rounded-lg bg-[#5D1C6A] text-white disabled:opacity-50 disabled:cursor-not-allowed hover:bg-[#CA5995] transition-colors"
           >
             <Send className="h-3.5 w-3.5" />

--- a/app/(product)/components/FriendChat.tsx
+++ b/app/(product)/components/FriendChat.tsx
@@ -11,6 +11,7 @@ import {
 } from "react-icons/fi";
 import { getAblyClient } from "@/lib/ably-client";
 import { chatChannel } from "@/lib/realtimeChannels";
+import { useEmailVerified } from "@/hooks/useEmailVerified";
 
 type SessionRequestPayload = {
   sessionRequestId: string;
@@ -56,6 +57,7 @@ export default function FriendChat({
   minimized = false,
   onMinimizeToggle,
 }: FriendChatProps) {
+  const { canInteract, message: verifyMessage } = useEmailVerified();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -402,7 +404,7 @@ export default function FriendChat({
 
   const sendText = async () => {
     const value = text.trim();
-    if (!value || !currentUserId) return;
+    if (!value || !currentUserId || !canInteract) return;
     const tempId = `temp-${Date.now()}-${Math.random().toString(36).slice(2)}`;
     const optimisticMessage: ChatMessage = {
       id: tempId,
@@ -441,6 +443,7 @@ export default function FriendChat({
   };
 
   const sendSessionRequest = async () => {
+    if (!canInteract) return;
     try {
       if (!srDate || srHour === null) throw new Error("Pick date & time");
       const startTime = new Date(srDate);
@@ -1254,8 +1257,13 @@ export default function FriendChat({
         <div className="flex items-center gap-2">
           <input
             type="text"
-            placeholder={`Message ${friendLabel.split(/[@\s]/)[0] || "friend"}…`}
-            className={`flex-1 rounded-full border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder:text-gray-400 focus:outline-none focus:border-[#5D1C6A] focus:bg-white dark:focus:border-[#CA5995] dark:focus:bg-gray-900 transition-colors ${
+            placeholder={
+              canInteract
+                ? `Message ${friendLabel.split(/[@\s]/)[0] || "friend"}…`
+                : verifyMessage
+            }
+            disabled={!canInteract}
+            className={`flex-1 rounded-full border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder:text-gray-400 focus:outline-none focus:border-[#5D1C6A] focus:bg-white dark:focus:border-[#CA5995] dark:focus:bg-gray-900 transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${
               isModal ? "px-4 py-2 text-sm" : "px-3 py-1.5 text-sm"
             }`}
             value={text}
@@ -1268,9 +1276,10 @@ export default function FriendChat({
             }}
           />
           <button
-            onClick={() => setSrOpen((v) => !v)}
+            onClick={() => canInteract && setSrOpen((v) => !v)}
+            disabled={!canInteract}
             aria-label={srOpen ? "Close session request" : "Send session request"}
-            title="Send session request"
+            title={canInteract ? "Send session request" : verifyMessage}
             className={`inline-flex shrink-0 items-center justify-center rounded-full border transition-colors ${
               srOpen
                 ? "border-[#5D1C6A] bg-[#FFF1D3] text-[#5D1C6A] dark:bg-[#5D1C6A]/40 dark:text-[#FFB090] dark:border-[#CA5995]"
@@ -1281,7 +1290,7 @@ export default function FriendChat({
           </button>
           <button
             onClick={sendText}
-            disabled={isSending || !text.trim()}
+            disabled={!canInteract || isSending || !text.trim()}
             aria-label="Send message"
             className={`inline-flex shrink-0 items-center justify-center rounded-full bg-[#5D1C6A] text-white shadow-sm hover:bg-[#CA5995] disabled:opacity-50 disabled:cursor-not-allowed transition-colors ${
               isModal ? "h-10 w-10" : "h-8 w-8"

--- a/app/(product)/components/Matchmaking.tsx
+++ b/app/(product)/components/Matchmaking.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Loader2, UserPlus, Zap } from "lucide-react";
+import { useEmailVerified } from "@/hooks/useEmailVerified";
 
 type MatchUser = {
   _id: string;
@@ -23,6 +24,7 @@ export default function Matchmaking() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [sentRequests, setSentRequests] = useState<Set<string>>(new Set());
+  const { canInteract, message: verifyMessage } = useEmailVerified();
 
   useEffect(() => {
     fetchMatches();
@@ -46,6 +48,7 @@ export default function Matchmaking() {
   };
 
   const sendFriendRequest = async (userId: string) => {
+    if (!canInteract) return;
     setSentRequests((prev) => {
       if (prev.has(userId)) return prev;
       const next = new Set(prev);
@@ -160,6 +163,8 @@ export default function Matchmaking() {
                 <Button 
                     className="w-full gap-2 bg-[#5D1C6A] hover:bg-[#CA5995] text-white"
                     onClick={() => sendFriendRequest(user._id)}
+                    disabled={!canInteract}
+                    title={!canInteract ? verifyMessage : undefined}
                 >
                     <UserPlus size={16} />
                     Connect

--- a/app/(product)/components/globalchat.tsx
+++ b/app/(product)/components/globalchat.tsx
@@ -7,6 +7,7 @@ import { VerifiedName } from "@/components/verified-tag";
 import { useSession } from "next-auth/react";
 import { getAblyClient } from "@/lib/ably-client";
 import { globalChatChannel } from "@/lib/realtimeChannels";
+import { useEmailVerified } from "@/hooks/useEmailVerified";
 
 type GlobalMessage = {
   id: string;
@@ -49,7 +50,8 @@ export default function GlobalChat() {
     "loading" | "friend" | "request_sent" | "none"
   >("none");
   const [profileFriendReqStatus, setProfileFriendReqStatus] = useState<string | null>(null);
-  const [myEmailVerified, setMyEmailVerified] = useState(false);
+  const { canInteract, verified: myEmailVerified, message: verifyMessage } =
+    useEmailVerified();
   const bottomRef = useRef<HTMLDivElement | null>(null);
   const topRef = useRef<HTMLDivElement | null>(null);
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
@@ -175,13 +177,6 @@ export default function GlobalChat() {
   }, [loadMore, pagination.hasMore, pagination.isLoadingMore]);
 
   useEffect(() => {
-    fetch("/api/users/me")
-      .then((res) => res.json())
-      .then((data) => setMyEmailVerified(!!data?.user?.emailVerified))
-      .catch(() => {});
-  }, []);
-
-  useEffect(() => {
     load();
     const client = getAblyClient();
     const channel = client.channels.get(globalChatChannel());
@@ -267,7 +262,7 @@ export default function GlobalChat() {
    */
   const send = async () => {
     const content = text.trim();
-    if (!content || isSending) return;
+    if (!content || isSending || !canInteract) return;
 
     // Generate a temporary ID for the optimistic message
     const tempId = `temp-${Date.now()}-${Math.random().toString(36).slice(2)}`;
@@ -279,7 +274,7 @@ export default function GlobalChat() {
       id: tempId,
       user_id: currentUserId!,
       user_name: userName,
-      emailVerified: myEmailVerified,
+      emailVerified: myEmailVerified === true,
       content: content,
       created_at: new Date().toISOString(),
       deleted: false,
@@ -749,7 +744,7 @@ export default function GlobalChat() {
                         {isOwnMessage ? (
                           <VerifiedName
                             name="You"
-                            verified={m.emailVerified ?? myEmailVerified}
+                            verified={m.emailVerified ?? myEmailVerified === true}
                             className="text-xs font-medium text-gray-600 dark:text-gray-400"
                           />
                         ) : m.username ? (
@@ -862,14 +857,14 @@ export default function GlobalChat() {
             value={text}
             onChange={(e) => setText(e.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder="Type a message..."
-            disabled={isSending}
+            placeholder={canInteract ? "Type a message..." : verifyMessage}
+            disabled={isSending || !canInteract}
             className="flex-1 rounded-xl border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 px-4 py-3 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#CA5995] dark:focus:ring-[#CA5995] focus:border-transparent disabled:opacity-50 disabled:cursor-not-allowed shadow-sm"
           />
           <button
             type="button"
             onClick={send}
-            disabled={!text.trim() || isSending}
+            disabled={!text.trim() || isSending || !canInteract}
             className="shrink-0 rounded-xl bg-[#5D1C6A] px-4 py-3 text-white shadow-sm hover:bg-[#CA5995] disabled:bg-gray-300 dark:disabled:bg-gray-600 disabled:cursor-not-allowed transition-colors flex items-center justify-center gap-2"
           >
             <Send className="h-4 w-4" />

--- a/app/api/ai/refine-goal/route.ts
+++ b/app/api/ai/refine-goal/route.ts
@@ -4,6 +4,7 @@ import { generateText } from 'ai';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { checkRateLimit, rateLimitedResponse } from '@/lib/ratelimit';
+import { requireVerifiedEmail } from '@/lib/requireVerifiedEmail';
 
 // Simple LRU cache to avoid re-calling the LLM for identical goal strings.
 // Keeps the most recent 200 entries. Entries expire after 1 hour.
@@ -39,6 +40,9 @@ export async function POST(req: Request) {
     if (!userId) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
     }
+
+    const emailGate = await requireVerifiedEmail(userId);
+    if (emailGate) return emailGate;
 
     // Rate limit AI calls
     const rl = await checkRateLimit(userId, 'ai');

--- a/app/api/backlog/issues/[id]/route.ts
+++ b/app/api/backlog/issues/[id]/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth";
 import { ObjectId } from "mongodb";
 import { authOptions } from "@/lib/auth";
 import { getDb } from "@/lib/mongodb";
+import { requireVerifiedEmail } from "@/lib/requireVerifiedEmail";
 
 type IssueStatus = "todo" | "in_progress" | "done";
 type IssuePriority = "low" | "medium" | "high";
@@ -39,6 +40,9 @@ export async function PATCH(
   if (!userId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
+
+  const emailGate = await requireVerifiedEmail(userId);
+  if (emailGate) return emailGate;
 
   const { id } = await params;
   if (!ObjectId.isValid(id)) {
@@ -122,6 +126,9 @@ export async function DELETE(
   if (!userId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
+
+  const emailGate = await requireVerifiedEmail(userId);
+  if (emailGate) return emailGate;
 
   const { id } = await params;
   if (!ObjectId.isValid(id)) {

--- a/app/api/backlog/issues/route.ts
+++ b/app/api/backlog/issues/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth";
 import { ObjectId } from "mongodb";
 import { authOptions } from "@/lib/auth";
 import { getDb } from "@/lib/mongodb";
+import { requireVerifiedEmail } from "@/lib/requireVerifiedEmail";
 
 type IssueStatus = "todo" | "in_progress" | "done";
 type IssuePriority = "low" | "medium" | "high";
@@ -62,6 +63,9 @@ export async function POST(req: NextRequest) {
   if (!userId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
+
+  const emailGate = await requireVerifiedEmail(userId);
+  if (emailGate) return emailGate;
 
   const body = await req.json().catch(() => ({}));
   const title = String(body?.title || "").trim();

--- a/app/api/chat/[friendId]/[messageId]/route.ts
+++ b/app/api/chat/[friendId]/[messageId]/route.ts
@@ -6,6 +6,7 @@ import { ObjectId } from "mongodb";
 import { areFriends } from "@/lib/friendship";
 import { chatChannel, publish } from "@/lib/sse";
 import { publishAbly } from "@/lib/ably-server";
+import { requireVerifiedEmail } from "@/lib/requireVerifiedEmail";
 
 type ChatMessageDoc = {
   _id: ObjectId;
@@ -54,6 +55,9 @@ export async function PATCH(
     ],
   });
   if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  const emailGate = await requireVerifiedEmail(ctx.currentUserId);
+  if (emailGate) return emailGate;
+
   if (existing.from_user_id !== ctx.currentUserId) {
     return NextResponse.json({ error: "You can only edit your own messages" }, { status: 403 });
   }
@@ -100,6 +104,9 @@ export async function DELETE(
     ],
   });
   if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  const emailGate = await requireVerifiedEmail(ctx.currentUserId);
+  if (emailGate) return emailGate;
+
   if (existing.from_user_id !== ctx.currentUserId) {
     return NextResponse.json({ error: "You can only delete your own messages" }, { status: 403 });
   }

--- a/app/api/chat/[friendId]/route.ts
+++ b/app/api/chat/[friendId]/route.ts
@@ -9,6 +9,7 @@ import { areFriends } from "@/lib/friendship";
 import { publishAbly } from "@/lib/ably-server";
 import { DURATION_OPTIONS } from "@/constants/calendar";
 import { hasSessionOverlap } from "@/lib/sessionOverlap";
+import { requireVerifiedEmail } from "@/lib/requireVerifiedEmail";
 
 type MessageDoc = {
   _id: ObjectId;
@@ -93,6 +94,9 @@ export async function POST(
   if (!currentUserId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
+
+  const emailGate = await requireVerifiedEmail(currentUserId);
+  if (emailGate) return emailGate;
 
   // Apply rate limiting for chat messages
   const rateLimitResult = await checkRateLimit(currentUserId, "chat");

--- a/app/api/community/posts/[postId]/comments/route.ts
+++ b/app/api/community/posts/[postId]/comments/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { getDb } from "@/lib/mongodb";
 import { ObjectId } from "mongodb";
+import { requireVerifiedEmail } from "@/lib/requireVerifiedEmail";
 
 // GET - Fetch comments for a post
 export async function GET(
@@ -83,6 +84,9 @@ export async function POST(
   const userId = (session?.user as { id?: string } | undefined)?.id;
   if (!userId)
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const emailGate = await requireVerifiedEmail(userId);
+  if (emailGate) return emailGate;
+
 
   const { postId } = await params;
 

--- a/app/api/community/posts/[postId]/like/route.ts
+++ b/app/api/community/posts/[postId]/like/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { getDb } from "@/lib/mongodb";
 import { ObjectId } from "mongodb";
+import { requireVerifiedEmail } from "@/lib/requireVerifiedEmail";
 
 // POST - Toggle like on a post
 export async function POST(
@@ -13,6 +14,9 @@ export async function POST(
   const userId = (session?.user as { id?: string } | undefined)?.id;
   if (!userId)
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const emailGate = await requireVerifiedEmail(userId);
+  if (emailGate) return emailGate;
+
 
   const { postId } = await params;
 

--- a/app/api/community/posts/[postId]/route.ts
+++ b/app/api/community/posts/[postId]/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { getDb } from "@/lib/mongodb";
 import { ObjectId } from "mongodb";
+import { requireVerifiedEmail } from "@/lib/requireVerifiedEmail";
 
 // DELETE - Delete a post (soft delete)
 export async function DELETE(
@@ -13,6 +14,9 @@ export async function DELETE(
   const userId = (session?.user as { id?: string } | undefined)?.id;
   if (!userId)
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const emailGate = await requireVerifiedEmail(userId);
+  if (emailGate) return emailGate;
+
 
   const { postId } = await params;
 

--- a/app/api/community/posts/route.ts
+++ b/app/api/community/posts/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { getDb } from "@/lib/mongodb";
 import { ObjectId } from "mongodb";
+import { requireVerifiedEmail } from "@/lib/requireVerifiedEmail";
 
 // GET - Fetch posts with pagination
 export async function GET(req: NextRequest) {
@@ -133,6 +134,9 @@ export async function POST(req: NextRequest) {
   const userId = (session?.user as { id?: string } | undefined)?.id;
   if (!userId)
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const emailGate = await requireVerifiedEmail(userId);
+  if (emailGate) return emailGate;
+
 
   const body = await req.json().catch(() => ({}));
   const { content } = body as { content?: string };

--- a/app/api/friends/[friendId]/route.ts
+++ b/app/api/friends/[friendId]/route.ts
@@ -6,6 +6,7 @@ import { ObjectId } from "mongodb";
 import { checkRateLimit, rateLimitedResponse } from "@/lib/ratelimit";
 import { chatChannel, publish } from "@/lib/sse";
 import { publishAbly } from "@/lib/ably-server";
+import { requireVerifiedEmail } from "@/lib/requireVerifiedEmail";
 
 // DELETE /api/friends/:friendId — remove an existing friendship.
 // Idempotent in spirit but returns 404 when no accepted relation exists so the
@@ -18,6 +19,9 @@ export async function DELETE(
   const currentUserId = (session?.user as { id?: string } | undefined)?.id;
   if (!currentUserId)
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const emailGate = await requireVerifiedEmail(currentUserId);
+  if (emailGate) return emailGate;
+
 
   const rl = await checkRateLimit(currentUserId, "api");
   if (!rl.success) return rateLimitedResponse(rl);

--- a/app/api/friends/requests/[id]/route.ts
+++ b/app/api/friends/requests/[id]/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from "@/lib/auth";
 import { getDb } from "@/lib/mongodb";
 import { ObjectId } from "mongodb";
 import { checkRateLimit, rateLimitedResponse } from "@/lib/ratelimit";
+import { requireVerifiedEmail } from "@/lib/requireVerifiedEmail";
 
 export async function POST(
   req: NextRequest,
@@ -13,6 +14,9 @@ export async function POST(
   const userId = (session?.user as { id?: string } | undefined)?.id;
   if (!userId)
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const emailGate = await requireVerifiedEmail(userId);
+  if (emailGate) return emailGate;
+
 
   // Rate limit friend request responses
   const rl = await checkRateLimit(userId, "api");

--- a/app/api/friends/requests/route.ts
+++ b/app/api/friends/requests/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from "@/lib/auth";
 import { getDb } from "@/lib/mongodb";
 import { ObjectId } from "mongodb";
 import { checkRateLimit, rateLimitedResponse } from "@/lib/ratelimit";
+import { requireVerifiedEmail } from "@/lib/requireVerifiedEmail";
 
 type FriendRequestDoc = {
   _id: ObjectId;
@@ -25,6 +26,9 @@ export async function POST(req: NextRequest) {
   const currentUserId = (session?.user as { id?: string } | undefined)?.id;
   if (!currentUserId)
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const emailGate = await requireVerifiedEmail(currentUserId);
+  if (emailGate) return emailGate;
+
 
   // Rate limit friend request creation
   const rl = await checkRateLimit(currentUserId, "api");

--- a/app/api/global-chat/[id]/route.ts
+++ b/app/api/global-chat/[id]/route.ts
@@ -5,6 +5,7 @@ import { getDb } from "@/lib/mongodb";
 import { ObjectId } from "mongodb";
 import { globalChatChannel, publish } from "@/lib/sse";
 import { publishAbly } from "@/lib/ably-server";
+import { requireVerifiedEmail } from "@/lib/requireVerifiedEmail";
 
 export async function PATCH(
   req: NextRequest,
@@ -16,6 +17,9 @@ export async function PATCH(
   if (!currentUserId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
+
+  const emailGate = await requireVerifiedEmail(currentUserId);
+  if (emailGate) return emailGate;
 
   const { id: messageId } = await params;
   if (!messageId) {
@@ -86,6 +90,9 @@ export async function DELETE(
   if (!currentUserId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
+
+  const emailGate = await requireVerifiedEmail(currentUserId);
+  if (emailGate) return emailGate;
 
   const { id: messageId } = await params;
 

--- a/app/api/global-chat/route.ts
+++ b/app/api/global-chat/route.ts
@@ -13,6 +13,7 @@ import {
 } from "@/lib/ratelimit";
 import { fetchEmailVerifiedMap } from "@/lib/users/emailVerifiedMap";
 import { isEmailVerified } from "@/lib/emailVerification";
+import { requireVerifiedEmail } from "@/lib/requireVerifiedEmail";
 
 /**
  * Default page size for pagination
@@ -163,6 +164,9 @@ export async function POST(req: NextRequest) {
   if (!currentUserId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
+
+  const emailGate = await requireVerifiedEmail(currentUserId);
+  if (emailGate) return emailGate;
 
   // Apply rate limiting for chat messages
   const rateLimitResult = await checkRateLimit(currentUserId, "chat");

--- a/app/api/session-requests/[id]/route.ts
+++ b/app/api/session-requests/[id]/route.ts
@@ -10,6 +10,7 @@ import { checkRateLimit, rateLimitedResponse } from "@/lib/ratelimit";
 import { DURATION_OPTIONS, type DurationMin } from "@/constants/calendar";
 import { hasSessionOverlap } from "@/lib/sessionOverlap";
 import { publishSessionDocUpserted } from "@/lib/sessionRealtime";
+import { requireVerifiedEmail } from "@/lib/requireVerifiedEmail";
 
 // POST /api/session-requests/:id { action: 'accept'|'decline', message?: string }
 // On accept: create a session and add both users as participants
@@ -21,6 +22,9 @@ export async function POST(
   const currentUserId = (session?.user as { id?: string } | undefined)?.id;
   if (!currentUserId)
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const emailGate = await requireVerifiedEmail(currentUserId);
+  if (emailGate) return emailGate;
+
 
   const rl = await checkRateLimit(currentUserId, "api");
   if (!rl.success) return rateLimitedResponse(rl);
@@ -209,6 +213,9 @@ export async function DELETE(
   const currentUserId = (session?.user as { id?: string } | undefined)?.id;
   if (!currentUserId)
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const emailGate = await requireVerifiedEmail(currentUserId);
+  if (emailGate) return emailGate;
+
 
   const { id } = await params;
   if (!ObjectId.isValid(id)) {

--- a/app/api/session-requests/route.ts
+++ b/app/api/session-requests/route.ts
@@ -7,6 +7,7 @@ import { areFriends } from "@/lib/friendship";
 import { checkRateLimit, rateLimitedResponse } from "@/lib/ratelimit";
 import { DURATION_OPTIONS, type DurationMin } from "@/constants/calendar";
 import { hasSessionOverlap } from "@/lib/sessionOverlap";
+import { requireVerifiedEmail } from "@/lib/requireVerifiedEmail";
 
 type SessionRequestDoc = {
   _id: ObjectId;
@@ -36,6 +37,9 @@ export async function POST(req: NextRequest) {
   const currentUserId = (session?.user as { id?: string } | undefined)?.id;
   if (!currentUserId)
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const emailGate = await requireVerifiedEmail(currentUserId);
+  if (emailGate) return emailGate;
+
 
   // Rate limit – session requests are user-facing notifications, so should be bounded.
   const rl = await checkRateLimit(currentUserId, "api");

--- a/app/api/sessions/[id]/attendance/route.ts
+++ b/app/api/sessions/[id]/attendance/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from "@/lib/auth";
 import { getDb } from "@/lib/mongodb";
 import { ObjectId } from "mongodb";
 import { checkRateLimit, rateLimitedResponse } from "@/lib/ratelimit";
+import { requireVerifiedEmail } from "@/lib/requireVerifiedEmail";
 
 // How close to end_time a leave needs to be for the session to count as
 // "completed". Mirrors the client-side COMPLETION_GRACE_MS in ClientCall.tsx.
@@ -35,6 +36,9 @@ export async function POST(
   if (!userId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
+
+  const emailGate = await requireVerifiedEmail(userId);
+  if (emailGate) return emailGate;
 
   const rl = await checkRateLimit(userId, "api");
   if (!rl.success) return rateLimitedResponse(rl);

--- a/app/api/sessions/[id]/daily/token/route.ts
+++ b/app/api/sessions/[id]/daily/token/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from "@/lib/auth";
 import { getDb } from "@/lib/mongodb";
 import { createOrGetDailyRoom, createDailyMeetingToken } from "@/lib/daily";
 import { checkRateLimit, rateLimitedResponse } from "@/lib/ratelimit";
+import { requireVerifiedEmail } from "@/lib/requireVerifiedEmail";
 import {
   CALL_JOIN_GRACE_MINUTES,
   isOwnerOrParticipant,
@@ -28,6 +29,9 @@ export async function POST(
   const userId = user?.id;
   if (!userId)
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const emailGate = await requireVerifiedEmail(userId);
+  if (emailGate) return emailGate;
+
 
   const rl = await checkRateLimit(userId, "api");
   if (!rl.success) return rateLimitedResponse(rl);

--- a/app/api/sessions/[id]/join/route.ts
+++ b/app/api/sessions/[id]/join/route.ts
@@ -6,6 +6,7 @@ import { ObjectId } from "mongodb";
 import { checkRateLimit, rateLimitedResponse } from "@/lib/ratelimit";
 import { hasSessionOverlap } from "@/lib/sessionOverlap";
 import { publishSessionDocUpserted } from "@/lib/sessionRealtime";
+import { requireVerifiedEmail } from "@/lib/requireVerifiedEmail";
 
 export async function POST(
   req: NextRequest,
@@ -16,6 +17,9 @@ export async function POST(
   const userId = (session?.user as AuthUser | undefined)?.id;
   if (!userId)
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const emailGate = await requireVerifiedEmail(userId);
+  if (emailGate) return emailGate;
+
 
   // Rate limit join attempts (prevents probing/spam)
   const rl = await checkRateLimit(userId, "api");

--- a/app/api/sessions/[id]/leave/route.ts
+++ b/app/api/sessions/[id]/leave/route.ts
@@ -5,6 +5,7 @@ import { getDb } from "@/lib/mongodb";
 import { ObjectId } from "mongodb";
 import { checkRateLimit, rateLimitedResponse } from "@/lib/ratelimit";
 import { publishSessionDocUpserted } from "@/lib/sessionRealtime";
+import { requireVerifiedEmail } from "@/lib/requireVerifiedEmail";
 
 type SessionDoc = {
   _id: ObjectId;
@@ -33,6 +34,9 @@ export async function POST(
   const userId = (session?.user as AuthUser | undefined)?.id;
   if (!userId)
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const emailGate = await requireVerifiedEmail(userId);
+  if (emailGate) return emailGate;
+
 
   // Rate limit (prevent thrashing)
   const rl = await checkRateLimit(userId, "api");

--- a/app/api/sessions/[id]/route.ts
+++ b/app/api/sessions/[id]/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from "@/lib/auth";
 import { getDb } from "@/lib/mongodb";
 import { ObjectId } from "mongodb";
 import { checkRateLimit, rateLimitedResponse } from "@/lib/ratelimit";
+import { requireVerifiedEmail } from "@/lib/requireVerifiedEmail";
 import {
   publishSessionDocUpserted,
   publishSessionRemoved,
@@ -82,6 +83,9 @@ export async function DELETE(
   const userId = (session?.user as AuthUser | undefined)?.id;
   if (!userId)
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const emailGate = await requireVerifiedEmail(userId);
+  if (emailGate) return emailGate;
+
 
   // Rate limit session mutations
   const rl = await checkRateLimit(userId, "api");
@@ -146,6 +150,9 @@ export async function PATCH(
   const userId = (session?.user as AuthUser | undefined)?.id;
   if (!userId)
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const emailGate = await requireVerifiedEmail(userId);
+  if (emailGate) return emailGate;
+
 
   // Rate limit session mutations
   const rlPatch = await checkRateLimit(userId, "api");

--- a/app/api/sessions/route.ts
+++ b/app/api/sessions/route.ts
@@ -8,6 +8,7 @@ import { publishSessionDocUpserted } from "@/lib/sessionRealtime";
 import { isEmailVerified } from "@/lib/emailVerification";
 import { DURATION_OPTIONS, SESSION_TYPES, type DurationMin, type SessionType } from "@/constants/calendar";
 import { hasSessionOverlap } from "@/lib/sessionOverlap";
+import { requireVerifiedEmail } from "@/lib/requireVerifiedEmail";
 
 // GET /api/sessions?from=ISO&to=ISO
 /** Soft cap on open (bookable) slots returned per range request. */
@@ -242,6 +243,9 @@ export async function POST(req: NextRequest) {
   const userId = (session?.user as { id?: string } | undefined)?.id;
   if (!userId)
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const emailGate = await requireVerifiedEmail(userId);
+  if (emailGate) return emailGate;
+
 
   // Rate limit session creation
   const rl = await checkRateLimit(userId, "api");

--- a/app/api/users/me/route.ts
+++ b/app/api/users/me/route.ts
@@ -9,6 +9,7 @@ import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { openai } from "@ai-sdk/openai";
 import { checkRateLimit, rateLimitedResponse } from "@/lib/ratelimit";
 import { isEmailVerified } from "@/lib/emailVerification";
+import { requireVerifiedEmail } from "@/lib/requireVerifiedEmail";
 
 export async function GET() {
   const session = await getServerSession(authOptions);
@@ -117,6 +118,9 @@ export async function PATCH(req: NextRequest) {
   const userId = (session?.user as { id?: string } | undefined)?.id;
   if (!userId)
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const emailGate = await requireVerifiedEmail(userId);
+  if (emailGate) return emailGate;
+
 
   // Rate limit profile updates
   const rl = await checkRateLimit(userId, "api");

--- a/app/api/users/preferences/route.ts
+++ b/app/api/users/preferences/route.ts
@@ -11,6 +11,7 @@ import {
   type SessionReminderTiming,
 } from "@/lib/sessionReminderPrefs";
 import { isValidTimeZone } from "@/lib/zonedTime";
+import { requireVerifiedEmail } from "@/lib/requireVerifiedEmail";
 
 /**
  * Read and update the current user's preferences. Stored under
@@ -68,6 +69,9 @@ export async function PATCH(req: NextRequest) {
   const userId = (session?.user as { id?: string } | undefined)?.id;
   if (!userId)
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const emailGate = await requireVerifiedEmail(userId);
+  if (emailGate) return emailGate;
+
 
   const rl = await checkRateLimit(userId, "api");
   if (!rl.success) return rateLimitedResponse(rl);

--- a/components/email-verification-strip.tsx
+++ b/components/email-verification-strip.tsx
@@ -56,7 +56,7 @@ export function EmailVerificationStrip() {
             ? "Verification email sent — check your inbox."
             : error
               ? error
-              : "Verify email — unlocks a trusted profile badge and other features."}
+              : "Verify your email to book sessions, chat, and post. You can browse every page until then."}
         </span>
       </div>
       <button

--- a/hooks/useEmailVerified.ts
+++ b/hooks/useEmailVerified.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { EMAIL_VERIFICATION_REQUIRED_MESSAGE } from "@/lib/emailVerificationMessages";
+
+export function useEmailVerified() {
+  const [verified, setVerified] = useState<boolean | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch("/api/users/me");
+      if (!res.ok) {
+        setVerified(null);
+        return;
+      }
+      const data = await res.json();
+      setVerified(!!data?.user?.emailVerified);
+    } catch {
+      setVerified(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return {
+    verified,
+    loading: verified === null,
+    canInteract: verified === true,
+    message: EMAIL_VERIFICATION_REQUIRED_MESSAGE,
+    refresh,
+  };
+}

--- a/lib/emailVerificationMessages.ts
+++ b/lib/emailVerificationMessages.ts
@@ -1,0 +1,4 @@
+export const EMAIL_NOT_VERIFIED_CODE = "EMAIL_NOT_VERIFIED";
+
+export const EMAIL_VERIFICATION_REQUIRED_MESSAGE =
+  "Verify your email to use this feature. You can browse until then.";

--- a/lib/requireVerifiedEmail.ts
+++ b/lib/requireVerifiedEmail.ts
@@ -1,0 +1,41 @@
+import { ObjectId } from "mongodb";
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/mongodb";
+import { isEmailVerified } from "@/lib/emailVerification";
+import {
+  EMAIL_NOT_VERIFIED_CODE,
+  EMAIL_VERIFICATION_REQUIRED_MESSAGE,
+} from "@/lib/emailVerificationMessages";
+
+export { EMAIL_NOT_VERIFIED_CODE, EMAIL_VERIFICATION_REQUIRED_MESSAGE };
+
+export async function getUserEmailVerified(userId: string): Promise<boolean> {
+  if (!ObjectId.isValid(userId)) return false;
+  const db = await getDb();
+  const user = await db.collection("users").findOne(
+    { _id: new ObjectId(userId) },
+    { projection: { emailVerified: 1 } },
+  );
+  if (!user) return false;
+  return isEmailVerified(user.emailVerified);
+}
+
+export function emailNotVerifiedResponse(): NextResponse {
+  return NextResponse.json(
+    {
+      error: EMAIL_VERIFICATION_REQUIRED_MESSAGE,
+      code: EMAIL_NOT_VERIFIED_CODE,
+    },
+    { status: 403 },
+  );
+}
+
+/** Returns a 403 response when unverified, or null when interaction is allowed. */
+export async function requireVerifiedEmail(
+  userId: string,
+): Promise<NextResponse | null> {
+  if (!(await getUserEmailVerified(userId))) {
+    return emailNotVerifiedResponse();
+  }
+  return null;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements read-only access for unverified users (issue #8 from the security audit):

- **Can:** sign in, browse every dashboard tab/page, read chat/community/sessions
- **Cannot:** book sessions, join calls, send chat messages, post/like/comment in community, send friend/session requests, edit profile/preferences, or use AI goal refinement

## Implementation

- `lib/requireVerifiedEmail.ts` — server helper returning `403` with `EMAIL_NOT_VERIFIED` code
- Applied to all mutating product API routes (sessions, chat, community, friends, backlog, AI refine-goal, profile/preferences PATCH)
- **Left open:** auth routes, resend/verify email, password change, account deletion, read endpoints
- `hooks/useEmailVerified.ts` — client hook to disable booking/chat/post controls with clear messaging
- Updated verification strip copy to explain browse-only mode

## Testing

- `npm test` — 106 tests passed
- `npm run build` — succeeded
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f31a3-e4fe-75eb-8bf6-4b4e40765ac8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f31a3-e4fe-75eb-8bf6-4b4e40765ac8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

