### PR TITLE
Fix Google sign-in failing on duplicate email index creation

### DIFF
--- a/__tests__/lib/upsertFirebaseUser.test.ts
+++ b/__tests__/lib/upsertFirebaseUser.test.ts
@@ -39,7 +39,6 @@ describe("upsertFirebaseUser", () => {
     usersCol.findOne.mockResolvedValue(null);
     usersCol.insertOne.mockResolvedValue({ insertedId: new ObjectId() });
     usersCol.updateOne.mockResolvedValue({ modifiedCount: 1 });
-    usersCol.createIndex.mockResolvedValue("email_1");
   });
 
   it("creates a new user with image and emailVerified", async () => {

--- a/lib/users/upsertFirebaseUser.ts
+++ b/lib/users/upsertFirebaseUser.ts
@@ -92,11 +92,6 @@ export async function upsertFirebaseUser(
   const db = await getDb();
   const usersCol = db.collection<UserDoc>("users");
 
-  await Promise.all([
-    usersCol.createIndex({ email: 1 }, { unique: true }),
-    usersCol.createIndex({ username: 1 }, { unique: true, sparse: true }),
-  ]);
-
   const existing = await usersCol.findOne({ email });
 
   if (existing) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Google sign-in failed with:

```
Index already exists with a different name: users_email_unique
```

On every Google login, `upsertFirebaseUser` called `createIndex({ email: 1 })` without a name. MongoDB auto-names that `email_1`, but the migration script already created `users_email_unique` on the same field.

## Fix

- Removed runtime `createIndex` calls from `upsertFirebaseUser.ts`
- Indexes are already managed by `npm run db:indexes` / `scripts/create-indexes.ts`

## Verification

- Connected to production MongoDB and confirmed indexes are correct:
  - `users_email_unique` on `{ email: 1 }`
  - `users_username_unique` on `{ username: 1 }` (sparse)
- Reproduced the error by calling `createIndex` without a name
- All `upsertFirebaseUser` unit tests pass

## Deploy note

No database migration needed — only a code deploy is required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5024-42ba-74b0-885d-33aee1249a28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5024-42ba-74b0-885d-33aee1249a28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

