### PR TITLE
Add admin Daily.co test call in dashboard

### DIFF
--- a/__tests__/api/admin/test-call.test.ts
+++ b/__tests__/api/admin/test-call.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ObjectId } from "mongodb";
+import { NextResponse } from "next/server";
+import { mockRequest, parseResponse } from "../../helpers";
+
+const createAdminTestCall = vi.hoisted(() => vi.fn());
+const listActiveAdminTestCalls = vi.hoisted(() => vi.fn());
+const logAdminAction = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/admin", () => ({
+  requireAdmin: vi.fn(),
+}));
+
+vi.mock("@/lib/adminAudit", () => ({
+  logAdminAction,
+}));
+
+vi.mock("@/lib/adminTestCall", () => ({
+  createAdminTestCall,
+  listActiveAdminTestCalls,
+  isValidAdminTestDuration: (value: unknown) =>
+    typeof value === "number" && [25, 50, 75].includes(value),
+}));
+
+import { requireAdmin } from "@/lib/admin";
+import { GET, POST } from "@/app/api/admin/test-call/route";
+
+describe("/api/admin/test-call", () => {
+  const adminId = String(new ObjectId());
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireAdmin).mockResolvedValue({
+      ok: true,
+      admin: { userId: adminId, email: "admin@example.com" },
+    });
+    logAdminAction.mockResolvedValue(undefined);
+    listActiveAdminTestCalls.mockResolvedValue([]);
+    createAdminTestCall.mockResolvedValue({
+      sessionId: String(new ObjectId()),
+      startTime: "2026-08-22T12:00:00.000Z",
+      endTime: "2026-08-22T12:25:00.000Z",
+      durationMin: 25,
+      callPagePath: "/sessions/abc",
+      roomName: "session-abc",
+      domain: "refocus.daily.co",
+      token: "daily-token",
+    });
+  });
+
+  it("rejects non-admins on GET", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+    });
+    const { status } = await parseResponse(await GET());
+    expect(status).toBe(403);
+  });
+
+  it("lists active admin test calls", async () => {
+    listActiveAdminTestCalls.mockResolvedValue([
+      {
+        sessionId: "s1",
+        startTime: "2026-08-22T12:00:00.000Z",
+        endTime: "2026-08-22T12:25:00.000Z",
+        durationMin: 25,
+        callPagePath: "/sessions/s1",
+        createdByUserId: adminId,
+      },
+    ]);
+    const { status, json } = await parseResponse(await GET());
+    expect(status).toBe(200);
+    expect(json.sessions).toHaveLength(1);
+    expect(json.sessions[0].callPagePath).toBe("/sessions/s1");
+  });
+
+  it("creates a test call and audits the action", async () => {
+    const req = mockRequest("/api/admin/test-call", {
+      method: "POST",
+      body: { durationMin: 50 },
+    });
+    const { status, json } = await parseResponse(await POST(req));
+    expect(status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.durationMin).toBe(25);
+    expect(createAdminTestCall).toHaveBeenCalledWith({
+      adminUserId: adminId,
+      adminName: "admin",
+      durationMin: 50,
+    });
+    expect(logAdminAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "test_call.create",
+        actorId: adminId,
+      }),
+    );
+  });
+
+  it("rejects invalid duration", async () => {
+    const req = mockRequest("/api/admin/test-call", {
+      method: "POST",
+      body: { durationMin: 99 },
+    });
+    const { status, json } = await parseResponse(await POST(req));
+    expect(status).toBe(400);
+    expect(json.error).toMatch(/Invalid durationMin/);
+    expect(createAdminTestCall).not.toHaveBeenCalled();
+  });
+});

--- a/app/(product)/components/Admin/AdminPanel.tsx
+++ b/app/(product)/components/Admin/AdminPanel.tsx
@@ -18,6 +18,7 @@ import {
   UserX,
   Users,
   UserPlus,
+  Video,
   Volume2,
   VolumeX,
   X,
@@ -34,6 +35,7 @@ import AdminMailbox, {
   type MailRecipient,
 } from "./AdminMailbox";
 import AdminCrew from "./AdminCrew";
+import AdminTestCall from "./AdminTestCall";
 
 type AdminSection =
   | "overview"
@@ -44,7 +46,8 @@ type AdminSection =
   | "history"
   | "ip-activity"
   | "logins"
-  | "crew";
+  | "crew"
+  | "test-call";
 
 type Stats = {
   users: {
@@ -247,6 +250,7 @@ const SECTIONS: {
   { id: "overview", label: "Overview", icon: LayoutDashboard },
   { id: "users", label: "Users", icon: Users },
   { id: "crew", label: "Crew", icon: UserPlus },
+  { id: "test-call", label: "Test call", icon: Video },
   { id: "logins", label: "Logins", icon: LogIn },
   { id: "deleted", label: "Deleted", icon: UserX },
   { id: "mailbox", label: "Mailbox", icon: Mail },
@@ -271,6 +275,7 @@ const ACTION_LABELS: Record<string, string> = {
   "user.email": "Emailed users",
   "crew.add": "Added crew member",
   "crew.remove": "Removed crew member",
+  "test_call.create": "Created Daily test call",
 };
 
 function StatCard({
@@ -1195,6 +1200,8 @@ export default function AdminPanel() {
         ) : null}
 
         {section === "crew" ? <AdminCrew active /> : null}
+
+        {section === "test-call" ? <AdminTestCall active /> : null}
 
         {section === "users" ? (
           <div className="space-y-4">

--- a/app/(product)/components/Admin/AdminTestCall.tsx
+++ b/app/(product)/components/Admin/AdminTestCall.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { ExternalLink, Loader2, Video } from "lucide-react";
+import { DURATION_OPTIONS, type DurationMin } from "@/constants/calendar";
+
+type ActiveTestCall = {
+  sessionId: string;
+  startTime: string;
+  endTime: string;
+  durationMin: number;
+  callPagePath: string;
+  createdByUserId: string;
+};
+
+type CreateResponse = ActiveTestCall & {
+  ok: true;
+  roomName: string;
+  domain: string;
+  token: string;
+};
+
+function formatWhen(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+export default function AdminTestCall({ active }: { active: boolean }) {
+  const [durationMin, setDurationMin] = useState<DurationMin>(25);
+  const [sessions, setSessions] = useState<ActiveTestCall[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [lastCreated, setLastCreated] = useState<CreateResponse | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/admin/test-call");
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Failed to load test calls");
+      setSessions(data.sessions || []);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (active) void load();
+  }, [active, load]);
+
+  const createTestCall = async () => {
+    setCreating(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/admin/test-call", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ durationMin }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Failed to create test call");
+      setLastCreated(data as CreateResponse);
+      await load();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-white">
+          Daily.co test call
+        </h2>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          Spin up a real session room to verify camera, mic, and Daily.co
+          integration without booking through the calendar.
+        </p>
+      </div>
+
+      <div className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4 space-y-4">
+        <div className="flex flex-wrap items-end gap-3">
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="text-xs font-medium uppercase tracking-wide text-gray-500">
+              Duration
+            </span>
+            <select
+              value={durationMin}
+              onChange={(e) =>
+                setDurationMin(Number(e.target.value) as DurationMin)
+              }
+              disabled={creating}
+              className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-950 px-3 py-2 text-sm"
+            >
+              {DURATION_OPTIONS.map((minutes) => (
+                <option key={minutes} value={minutes}>
+                  {minutes} minutes
+                </option>
+              ))}
+            </select>
+          </label>
+          <button
+            type="button"
+            onClick={() => void createTestCall()}
+            disabled={creating}
+            className="inline-flex items-center gap-2 rounded-lg bg-[#5D1C6A] px-4 py-2 text-sm font-medium text-white hover:bg-[#CA5995] disabled:opacity-60"
+          >
+            {creating ? (
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+            ) : (
+              <Video className="h-4 w-4" aria-hidden />
+            )}
+            {creating ? "Creating…" : "Create test call"}
+          </button>
+        </div>
+
+        {lastCreated ? (
+          <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-900 dark:border-emerald-900 dark:bg-emerald-950/30 dark:text-emerald-200">
+            <p className="font-medium">Test call ready</p>
+            <p className="mt-1 text-xs opacity-90">
+              Room <code>{lastCreated.roomName}</code> · ends{" "}
+              {formatWhen(lastCreated.endTime)}
+            </p>
+            <Link
+              href={lastCreated.callPagePath}
+              className="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-emerald-700 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-600"
+            >
+              Join test call
+              <ExternalLink className="h-3.5 w-3.5" aria-hidden />
+            </Link>
+          </div>
+        ) : null}
+      </div>
+
+      {error ? (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+        <div className="flex items-center justify-between gap-2">
+          <p className="text-xs font-medium uppercase tracking-wide text-gray-500">
+            Active test calls
+          </p>
+          <button
+            type="button"
+            onClick={() => void load()}
+            disabled={loading}
+            className="text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
+          >
+            Refresh
+          </button>
+        </div>
+        {loading && sessions.length === 0 ? (
+          <p className="mt-3 text-sm text-gray-500">Loading…</p>
+        ) : sessions.length === 0 ? (
+          <p className="mt-3 text-sm text-gray-500">
+            No active test calls. Create one above to join a room.
+          </p>
+        ) : (
+          <ul className="mt-3 divide-y divide-gray-100 dark:divide-gray-800">
+            {sessions.map((session) => (
+              <li
+                key={session.sessionId}
+                className="flex flex-wrap items-center justify-between gap-3 py-3 first:pt-0 last:pb-0"
+              >
+                <div className="min-w-0">
+                  <p className="text-sm font-medium text-gray-900 dark:text-white">
+                    {session.durationMin} min · {formatWhen(session.startTime)}
+                  </p>
+                  <p className="text-xs text-gray-500">
+                    Ends {formatWhen(session.endTime)}
+                  </p>
+                </div>
+                <Link
+                  href={session.callPagePath}
+                  className="inline-flex items-center gap-1 rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-1.5 text-sm hover:bg-gray-50 dark:hover:bg-gray-800"
+                >
+                  Join
+                  <ExternalLink className="h-3.5 w-3.5" aria-hidden />
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/api/admin/test-call/route.ts
+++ b/app/api/admin/test-call/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/admin";
+import { logAdminAction } from "@/lib/adminAudit";
+import {
+  createAdminTestCall,
+  isValidAdminTestDuration,
+  listActiveAdminTestCalls,
+} from "@/lib/adminTestCall";
+
+export async function GET() {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+
+  const sessions = await listActiveAdminTestCalls();
+  return NextResponse.json({ sessions });
+}
+
+export async function POST(req: NextRequest) {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+
+  const body = (await req.json().catch(() => ({}))) as {
+    durationMin?: unknown;
+  };
+  const durationMin = body.durationMin;
+  if (durationMin !== undefined && !isValidAdminTestDuration(durationMin)) {
+    return NextResponse.json(
+      { error: "Invalid durationMin (allowed: 25, 50, 75)" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await createAdminTestCall({
+      adminUserId: guard.admin.userId,
+      adminName: guard.admin.email.split("@")[0],
+      durationMin: isValidAdminTestDuration(durationMin)
+        ? durationMin
+        : undefined,
+    });
+
+    await logAdminAction({
+      actorId: guard.admin.userId,
+      actorEmail: guard.admin.email,
+      action: "test_call.create",
+      resourceId: result.sessionId,
+      details: {
+        durationMin: result.durationMin,
+        endTime: result.endTime,
+      },
+    });
+
+    return NextResponse.json({ ok: true, ...result });
+  } catch (err) {
+    console.error("[admin/test-call] Failed to create test call", err);
+    const message =
+      err instanceof Error ? err.message : "Failed to create test call";
+    const status = message.includes("DAILY") ? 503 : 500;
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/lib/adminAudit.ts
+++ b/lib/adminAudit.ts
@@ -16,7 +16,8 @@ export type AdminAuditAction =
   | "report.resolve"
   | "user.email"
   | "crew.add"
-  | "crew.remove";
+  | "crew.remove"
+  | "test_call.create";
 
 export type AdminAuditEntry = {
   _id?: ObjectId;

--- a/lib/adminTestCall.ts
+++ b/lib/adminTestCall.ts
@@ -1,0 +1,132 @@
+import { ObjectId } from "mongodb";
+import { getDb } from "@/lib/mongodb";
+import { createOrGetDailyRoom, createDailyMeetingToken } from "@/lib/daily";
+import {
+  CALL_JOIN_GRACE_MINUTES,
+  WRAP_UP_MINUTES,
+} from "@/lib/sessionAccess";
+import {
+  DURATION_OPTIONS,
+  type DurationMin,
+} from "@/constants/calendar";
+
+export type AdminTestCallResult = {
+  sessionId: string;
+  startTime: string;
+  endTime: string;
+  durationMin: DurationMin;
+  callPagePath: string;
+  roomName: string;
+  domain: string;
+  token: string;
+};
+
+export function isValidAdminTestDuration(
+  value: unknown,
+): value is DurationMin {
+  return (
+    typeof value === "number" &&
+    (DURATION_OPTIONS as readonly number[]).includes(value)
+  );
+}
+
+export async function createAdminTestCall(params: {
+  adminUserId: string;
+  adminName?: string | null;
+  durationMin?: DurationMin;
+}): Promise<AdminTestCallResult> {
+  const durationMin = params.durationMin ?? 25;
+  const now = new Date();
+  const startTime = now;
+  const endTime = new Date(now.getTime() + durationMin * 60_000);
+
+  const db = await getDb();
+  const insert = await db.collection("sessions").insertOne({
+    owner_id: params.adminUserId,
+    start_time: startTime,
+    end_time: endTime,
+    duration_min: durationMin,
+    session_type: "focus",
+    status: "available",
+    participant_count: 1,
+    is_admin_test: true,
+    name: "Admin test call",
+    session_participants: [
+      {
+        user_id: params.adminUserId,
+        joined_at: now,
+        quiet: false,
+      },
+    ],
+    created_at: now,
+    updated_at: now,
+  });
+
+  const sessionId = String(insert.insertedId);
+  const sessionEndExp =
+    Math.floor(endTime.getTime() / 1000) + 30 * 60;
+  const { roomName, domain } = await createOrGetDailyRoom(
+    sessionId,
+    sessionEndExp,
+  );
+  const tokenExp =
+    Math.floor(endTime.getTime() / 1000) +
+    Math.max(CALL_JOIN_GRACE_MINUTES, WRAP_UP_MINUTES) * 60;
+  const token = await createDailyMeetingToken(roomName, params.adminUserId, {
+    userName: params.adminName?.trim() || "Admin",
+    exp: tokenExp,
+  });
+
+  return {
+    sessionId,
+    startTime: startTime.toISOString(),
+    endTime: endTime.toISOString(),
+    durationMin,
+    callPagePath: `/sessions/${sessionId}`,
+    roomName,
+    domain,
+    token,
+  };
+}
+
+export async function listActiveAdminTestCalls(): Promise<
+  Array<{
+    sessionId: string;
+    startTime: string;
+    endTime: string;
+    durationMin: number;
+    callPagePath: string;
+    createdByUserId: string;
+  }>
+> {
+  const db = await getDb();
+  const now = new Date();
+  const graceMs = CALL_JOIN_GRACE_MINUTES * 60 * 1000;
+  const rows = await db
+    .collection("sessions")
+    .find({
+      is_admin_test: true,
+      end_time: { $gte: new Date(now.getTime() - graceMs) },
+    })
+    .sort({ created_at: -1 })
+    .limit(20)
+    .toArray();
+
+  return rows
+    .filter((row) => {
+      const end = row.end_time ? new Date(row.end_time as Date).getTime() : 0;
+      return now.getTime() <= end + graceMs;
+    })
+    .map((row) => ({
+      sessionId: String(row._id),
+      startTime: new Date(row.start_time as Date).toISOString(),
+      endTime: new Date(row.end_time as Date).toISOString(),
+      durationMin: (row.duration_min as number) ?? 25,
+      callPagePath: `/sessions/${String(row._id)}`,
+      createdByUserId: String(row.owner_id),
+    }));
+}
+
+export function adminTestCallObjectId(id: string): ObjectId | null {
+  return ObjectId.isValid(id) ? new ObjectId(id) : null;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Test call** tab to the admin dashboard so admins can spin up an immediate Daily.co session for testing camera, mic, and call integration without booking through the calendar.

## Changes

- New `POST /api/admin/test-call` endpoint (admin-only) that:
  - Creates a MongoDB session marked `is_admin_test: true` starting immediately
  - Provisions the Daily room and meeting token
  - Returns a link to the existing `/sessions/[id]` join page
- New `GET /api/admin/test-call` endpoint to list active admin test calls
- New **Test call** section in the admin panel with duration picker, create button, and join links
- Audit log action `test_call.create`
- Unit tests for the API route

## How to use

1. Go to **Dashboard → Admin → Test call**
2. Pick a duration (25 / 50 / 75 min)
3. Click **Create test call**
4. Click **Join test call** to open the standard session call page

Requires `DAILY_API_KEY` and `DAILY_DOMAIN` to be configured on the server.

## Test plan

- [x] `npx vitest run __tests__/api/admin/test-call.test.ts`
- [ ] Manual: create test call as admin and join the room
- [ ] Manual: verify non-admin cannot access `/api/admin/test-call`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f50cb-5868-7382-a870-d68fa8ead6a5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f50cb-5868-7382-a870-d68fa8ead6a5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

